### PR TITLE
Allow rendering view models via render()

### DIFF
--- a/test/ZendViewRendererTest.php
+++ b/test/ZendViewRendererTest.php
@@ -376,5 +376,6 @@ class ZendViewRendererTest extends TestCase
 
         $content = file_get_contents(__DIR__ . '/TestAsset/zendview.phtml');
         $content = str_replace('<?php echo $name ?>', 'Zend', $content);
+        $this->assertEquals($content, $result);
     }
 }

--- a/test/ZendViewRendererTest.php
+++ b/test/ZendViewRendererTest.php
@@ -338,16 +338,43 @@ class ZendViewRendererTest extends TestCase
         $this->assertEquals($content, $result);
     }
 
-    public function testOverrideSharedParametersAtRender()
+    public function useArrayOrViewModel()
+    {
+        return [
+            'array'      => [false],
+            'view-model' => [true],
+        ];
+    }
+
+    /**
+     * @dataProvider useArrayOrViewModel
+     */
+    public function testOverrideSharedParametersAtRender($viewAsModel)
     {
         $renderer = new ZendViewRenderer();
         $renderer->addPath(__DIR__ . '/TestAsset');
         $name = 'Zend';
         $name2 = 'View';
         $renderer->addDefaultParam($renderer::TEMPLATE_ALL, 'name', $name);
-        $result = $renderer->render('zendview', ['name' => $name2]);
+
+        $viewModel = ['name' => $name2];
+        $viewModel = $viewAsModel ? new ViewModel($viewModel) : $viewModel;
+
+        $result = $renderer->render('zendview', $viewModel);
         $content = file_get_contents(__DIR__ . '/TestAsset/zendview.phtml');
         $content = str_replace('<?php echo $name ?>', $name2, $content);
         $this->assertEquals($content, $result);
+    }
+
+    public function testWillRenderAViewModel()
+    {
+        $renderer = new ZendViewRenderer();
+        $renderer->addPath(__DIR__ . '/TestAsset');
+
+        $viewModel = new ViewModel(['name' => 'Zend']);
+        $result = $renderer->render('zendview', $viewModel);
+
+        $content = file_get_contents(__DIR__ . '/TestAsset/zendview.phtml');
+        $content = str_replace('<?php echo $name ?>', 'Zend', $content);
     }
 }


### PR DESCRIPTION
Per the request in #2, and as an alternative to #3, this patch allows rendering a view model directly from the `render()` method, in a fashion similar to that used in [phly-expressive-mustache](https://github.com/phly/phly-expressive-mustache). Internally, the following changes were made:
- Added a method, `mergeViewModel()`, which ensures that global/template variables are merged into a provided view model instance, and that the template name provided to `render()` is injected.
- Extracted the method `prepareLayout()` from `createModel()`; this method accepts a view model, determines if a layout is present in either the renderer or the view model, and, if so, prepares it and injects it with the passed view model as a child.
- Modified `createModel()` to merge provided parameters with global/template parameters, create the view model, and inject it with the template name. It no longer does the layout preparation.
- Updated `render()` to test if `$params` is a `ModelInterface` instance. If so, the argument is passed to `mergeViewModel()`; otherwise, to `createModel()`. On completion, the resulting view model is passed to `prepareLayout()`, and the result of that operation is passed to `renderModel()`.

A new test was created, `testWillRenderAViewModel()`, and the method `testOverrideSharedParametersAtRender()` was updated to test both array and `ModelInterface` arguments to `render()` to ensure variable overrides happen correctly in either situation.
