### PR TITLE
Implement RouteResultObserverInterface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": ">=5.5",
         "container-interop/container-interop": "^1.1",
-        "zendframework/zend-expressive": "^1.0@rc",
+        "zendframework/zend-expressive": "~1.0.0-dev@dev",
         "zendframework/zend-filter": "^2.5",
         "zendframework/zend-i18n": "^2.5",
         "zendframework/zend-servicemanager": "^2.5",

--- a/src/ApplicationUrlDelegatorFactory.php
+++ b/src/ApplicationUrlDelegatorFactory.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\ZendView;
+
+use Zend\ServiceManager\DelegatorFactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class ApplicationUrlDelegatorFactory implements DelegatorFactoryInterface
+{
+    /**
+     * Inject the UrlHelper in an Application instance, when available.
+     *
+     * @param ServiceLocatorInterface $container
+     * @param string $name
+     * @param string $requestedName
+     * @param callable $callback Callback that returns the Application instance
+     */
+    public function createDelegatorWithName(ServiceLocatorInterface $container, $name, $requestedName, $callback)
+    {
+        $application = $callback();
+        if ($container->has(UrlHelper::class)) {
+            $application->attachRouteResultObserver($container->get(UrlHelper::class));
+        }
+        return $application;
+    }
+}

--- a/src/UrlHelper.php
+++ b/src/UrlHelper.php
@@ -10,9 +10,10 @@ namespace Zend\Expressive\ZendView;
 use Zend\Expressive\Exception;
 use Zend\Expressive\Router\RouterInterface;
 use Zend\Expressive\Router\RouteResult;
+use Zend\Expressive\Router\RouteResultObserverInterface;
 use Zend\View\Helper\AbstractHelper;
 
-class UrlHelper extends AbstractHelper
+class UrlHelper extends AbstractHelper implements RouteResultObserverInterface
 {
     /**
      * @var RouteResult
@@ -60,6 +61,14 @@ class UrlHelper extends AbstractHelper
         }
 
         return $this->router->generateUri($route, $params);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function update(RouteResult $result)
+    {
+        $this->result = $result;
     }
 
     /**

--- a/src/UrlHelperFactory.php
+++ b/src/UrlHelperFactory.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\ZendView;
+
+use Interop\Container\ContainerInterface;
+use Zend\Expressive\Router\RouterInterface;
+
+class UrlHelperFactory
+{
+    /**
+     * Create a UrlHelper instance.
+     *
+     * @param ContainerInterface $container
+     * @return UrlHelper
+     */
+    public function __invoke(ContainerInterface $container)
+    {
+        return new UrlHelper($container->get(RouterInterface::class));
+    }
+}

--- a/src/ZendViewRendererFactory.php
+++ b/src/ZendViewRendererFactory.php
@@ -103,6 +103,9 @@ class ZendViewRendererFactory
             : new HelperPluginManager();
 
         $helpers->setFactory('url', function () use ($container) {
+            if ($container->has(UrlHelper::class)) {
+                return $container->get(UrlHelper::class);
+            }
             return new UrlHelper($container->get(RouterInterface::class));
         });
         $helpers->setInvokableClass('serverurl', ServerUrlHelper::class);

--- a/test/ApplicationUrlDelegatorFactoryTest.php
+++ b/test/ApplicationUrlDelegatorFactoryTest.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Expressive\ZendView;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Expressive\Application;
+use Zend\Expressive\ZendView\ApplicationUrlDelegatorFactory;
+use Zend\Expressive\ZendView\UrlHelper;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class ApplicationUrlDelegatorFactoryTest extends TestCase
+{
+    public function testDelegatorRegistersUrlHelperAsRouteResultObserverWithApplication()
+    {
+        $urlHelper = $this->prophesize(UrlHelper::class);
+        $application = $this->prophesize(Application::class);
+        $application->attachRouteResultObserver($urlHelper->reveal())->shouldBeCalled();
+        $applicationCallback = function () use ($application) {
+            return $application->reveal();
+        };
+
+        $container = $this->prophesize(ServiceLocatorInterface::class);
+        $container->has(UrlHelper::class)->willReturn(true);
+        $container->get(UrlHelper::class)->willReturn($urlHelper->reveal());
+
+        $delegator = new ApplicationUrlDelegatorFactory();
+        $test = $delegator->createDelegatorWithName(
+            $container->reveal(),
+            Application::class,
+            Application::class,
+            $applicationCallback
+        );
+        $this->assertSame($application->reveal(), $test);
+    }
+}

--- a/test/UrlHelperTest.php
+++ b/test/UrlHelperTest.php
@@ -14,6 +14,7 @@ use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Expressive\Exception;
 use Zend\Expressive\Router\RouterInterface;
 use Zend\Expressive\Router\RouteResult;
+use Zend\Expressive\Router\RouteResultObserverInterface;
 use Zend\Expressive\ZendView\UrlHelper;
 
 class UrlHelperTest extends TestCase
@@ -133,5 +134,19 @@ class UrlHelperTest extends TestCase
         $helper->setRouteResult($result->reveal());
 
         $this->assertEquals('URL', $helper('resource', ['id' => 2]));
+    }
+
+    public function testIsARouteResultObserver()
+    {
+        $helper = $this->createHelper();
+        $this->assertInstanceOf(RouteResultObserverInterface::class, $helper);
+    }
+
+    public function testUpdateMethodSetsRouteResultProperty()
+    {
+        $result = $this->prophesize(RouteResult::class);
+        $helper = $this->createHelper();
+        $helper->update($result->reveal());
+        $this->assertAttributeSame($result->reveal(), 'result', $helper);
     }
 }

--- a/test/ZendViewRendererFactoryTest.php
+++ b/test/ZendViewRendererFactoryTest.php
@@ -210,6 +210,7 @@ class ZendViewRendererFactoryTest extends TestCase
         $router = $this->prophesize(RouterInterface::class)->reveal();
         $this->container->has('config')->willReturn(false);
         $this->container->has(HelperPluginManager::class)->willReturn(false);
+        $this->container->has(UrlHelper::class)->willReturn(false);
         $this->container->has(RouterInterface::class)->willReturn(true);
         $this->container->get(RouterInterface::class)->willReturn($router);
         $factory = new ZendViewRendererFactory();
@@ -231,6 +232,7 @@ class ZendViewRendererFactoryTest extends TestCase
         $this->container->has('config')->willReturn(false);
         $this->container->has(RouterInterface::class)->willReturn(true);
         $this->container->get(RouterInterface::class)->willReturn($router);
+        $this->container->has(UrlHelper::class)->willReturn(false);
 
         $helpers = new HelperPluginManager();
         $this->container->has(HelperPluginManager::class)->willReturn(true);
@@ -253,5 +255,24 @@ class ZendViewRendererFactoryTest extends TestCase
         $this->assertTrue($helpers->has('serverurl'));
         $this->assertInstanceOf(UrlHelper::class, $helpers->get('url'));
         $this->assertInstanceOf(ServerUrlHelper::class, $helpers->get('serverurl'));
+    }
+
+    public function testWillUseUrlHelperFromContainerWhenAvailable()
+    {
+        $urlHelper = $this->prophesize(UrlHelper::class)->reveal();
+        $router = $this->prophesize(RouterInterface::class)->reveal();
+        $this->container->has('config')->willReturn(false);
+        $this->container->has(HelperPluginManager::class)->willReturn(false);
+        $this->container->has(UrlHelper::class)->willReturn(true);
+        $this->container->get(UrlHelper::class)->willReturn($urlHelper);
+        $this->container->has(RouterInterface::class)->willReturn(true);
+        $this->container->get(RouterInterface::class)->willReturn($router);
+        $factory = new ZendViewRendererFactory();
+        $view    = $factory($this->container->reveal());
+
+        $renderer = $this->fetchPhpRenderer($view);
+        $helpers  = $renderer->getHelperPluginManager();
+        $this->assertTrue($helpers->has('url'));
+        $this->assertSame($urlHelper, $helpers->get('url'));
     }
 }


### PR DESCRIPTION
This patch updates the `UrlHelper` to implement the new [RouteResultObserverInterface](zendframework/zend-expressive#200).

Additionally, it provides a delegator factory for registering the `UrlHelper` as a `RouteResult` observer to the `Application` instance, via the following:
- Creates a `UrlHelperFactory` for creating the `UrlHelper`, to register under the service name `Zend\Expressive\ZendView\UrlHelper` in the application container. (This simplifies usage of the delegator factory).
- Updates the `ZendViewRendererFactory` to test for, and pull when present, the `Zend\Expressive\ZendView\UrlHelper` to create the URL helper.
- Provides `ApplicationUrlDelegatorFactory` for injecting the `UrlHelper` as a `RouteResult` observer to the application instance; to do this, it checks to see if the `Zend\Expressive\ZendView\UrlHelper` is present, and, if so, uses that instance. (This minimizes the number of objects present in the dependency graph for cases when no template renderer is required.)
