### PR TITLE
Factory for helper plugin manager

### DIFF
--- a/src/HelperPluginManagerFactory.php
+++ b/src/HelperPluginManagerFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Zend\Expressive\ZendView;
+
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\Config;
+use Zend\View\HelperPluginManager;
+
+class HelperPluginManagerFactory
+{
+    public function __invoke(ContainerInterface $container)
+    {
+        $config = $container->has('config') ? $container->get('config') : [];
+        $config = isset($config['view_helpers']) ? $config['view_helpers'] : [];
+        $manager = new HelperPluginManager(new Config($config));
+        $manager->setServiceLocator($container);
+
+        return $manager;
+    }
+}

--- a/test/HelperPluginManagerFactoryTest.php
+++ b/test/HelperPluginManagerFactoryTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Expressive\ZendView;
+
+use Interop\Container\ContainerInterface;
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Expressive\ZendView\HelperPluginManagerFactory;
+use Zend\ServiceManager\ServiceManager;
+use Zend\View\HelperPluginManager;
+use ZendTest\Expressive\ZendView\TestAsset\TestHelper;
+
+class HelperPluginManagerFactoryTest extends TestCase
+{
+    /**
+     * @var ContainerInterface
+    */
+    private $container;
+
+    public function setUp()
+    {
+        $this->container = $this->prophesize(ServiceManager::class);
+    }
+
+    public function testCallingFactoryWithNoConfigReturnsHelperPluginManagerInstance()
+    {
+        $this->container->has('config')->willReturn(false);
+        $factory = new HelperPluginManagerFactory();
+        $manager = $factory($this->container->reveal());
+        $this->assertInstanceOf(HelperPluginManager::class, $manager);
+        return $manager;
+    }
+
+    public function testCallingFactoryWithNoViewHelperConfigReturnsHelperPluginManagerInstance()
+    {
+        $this->container->has('config')->willReturn(true);
+        $this->container->get('config')->willReturn([]);
+        $factory = new HelperPluginManagerFactory();
+        $manager = $factory($this->container->reveal());
+        $this->assertInstanceOf(HelperPluginManager::class, $manager);
+        return $manager;
+    }
+
+    public function testCallingFactoryWithConfigAllowsAddingHelpers()
+    {
+        $this->container->has('config')->willReturn(true);
+        $this->container->get('config')->willReturn(
+            [
+                'view_helpers' => [
+                    'invokables' => [
+                        'testHelper' => TestHelper::class,
+                    ],
+                ],
+            ]
+        );
+        $factory = new HelperPluginManagerFactory();
+        $manager = $factory($this->container->reveal());
+        $this->assertInstanceOf(HelperPluginManager::class, $manager);
+        $this->assertTrue($manager->has('testHelper'));
+        $this->assertInstanceOf(TestHelper::class, $manager->get('testHelper'));
+        return $manager;
+    }
+}

--- a/test/TestAsset/TestHelper.php
+++ b/test/TestAsset/TestHelper.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace ZendTest\Expressive\ZendView\TestAsset;
+
+use Zend\View\Helper\AbstractHelper;
+
+class TestHelper extends AbstractHelper
+{
+}


### PR DESCRIPTION
This patch brings factory for `HelperPluginManager`. Having this factory allows adding custom view helpers using configuration:

``` php
return [
    'view_helpers' => [
        'invokables' => [
            'translate' => Translate::class,
        ],
        'factories' => [
            'asset' => AssetHelperFactory::class,
        ],
    ],
];
```

After this is merged, I will update Skeleton App and documentation.
