### PR TITLE
Update to use RouteResultObserverInterface from zend-expressive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,6 @@ sudo: false
 
 language: php
 
-cache:
-  directories:
-    - $HOME/.composer/cache
-    - vendor
-
 matrix:
   fast_finish: true
   include:

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": ">=5.5",
+        "php": "^5.5 || ^7.0",
         "container-interop/container-interop": "^1.1",
         "psr/http-message": "^1.0",
         "zendframework/zend-expressive-router": "^1.0",
@@ -31,7 +31,7 @@
         "phpunit/phpunit": "^4.7",
         "squizlabs/php_codesniffer": "^2.3",
         "zendframework/zend-diactoros": "^1.2",
-        "zendframework/zend-expressive": "~1.0.0-dev@dev"
+        "zendframework/zend-expressive": "~1.0.0-dev@dev || ^1.0"
     },
     "autoload": {
       "psr-4": {

--- a/src/UrlHelper.php
+++ b/src/UrlHelper.php
@@ -10,7 +10,7 @@ namespace Zend\Expressive\ZendView;
 use Zend\Expressive\Router\Exception\RuntimeException;
 use Zend\Expressive\Router\RouterInterface;
 use Zend\Expressive\Router\RouteResult;
-use Zend\Expressive\Router\RouteResultObserverInterface;
+use Zend\Expressive\RouteResultObserverInterface;
 use Zend\Expressive\Template\Exception\RenderingException;
 use Zend\View\Helper\AbstractHelper;
 

--- a/test/UrlHelperTest.php
+++ b/test/UrlHelperTest.php
@@ -14,7 +14,7 @@ use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Expressive\Router\Exception\RuntimeException;
 use Zend\Expressive\Router\RouterInterface;
 use Zend\Expressive\Router\RouteResult;
-use Zend\Expressive\Router\RouteResultObserverInterface;
+use Zend\Expressive\RouteResultObserverInterface;
 use Zend\Expressive\Template\Exception;
 use Zend\Expressive\ZendView\UrlHelper;
 


### PR DESCRIPTION
Following on zendframework/zend-expressive#206, this patch updates the `UrlHelper` to implement `Zend\Expressive\RouteResultObserverInterface` instead of `Zend\Expressive\Router\RouteResultObserverInterface`, which is now deprecated.
