### PR TITLE
Updated dependency versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": "^5.5 || ^7.0",
         "container-interop/container-interop": "^1.1",
         "psr/http-message": "^1.0",
-        "zendframework/zend-expressive-helpers": "^1.0",
+        "zendframework/zend-expressive-helpers": "^1.1",
         "zendframework/zend-expressive-template": "^1.0.1",
         "zendframework/zend-filter": "^2.5",
         "zendframework/zend-i18n": "^2.5",
@@ -29,8 +29,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^4.7",
-        "squizlabs/php_codesniffer": "^2.3",
-        "zendframework/zend-expressive": "~1.0.0-dev@dev || ^1.0"
+        "squizlabs/php_codesniffer": "^2.3"
     },
     "autoload": {
       "psr-4": {


### PR DESCRIPTION
- zend-expressive-helpers `^1.1`
- which allows removing zend-expressive as a dev requirement
