### PR TITLE
Updated zend-expressive-helpers version to 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": "^5.5 || ^7.0",
         "container-interop/container-interop": "^1.1",
         "psr/http-message": "^1.0",
-        "zendframework/zend-expressive-helpers": "^1.1",
+        "zendframework/zend-expressive-helpers": "^2.0",
         "zendframework/zend-expressive-template": "^1.0.1",
         "zendframework/zend-filter": "^2.5",
         "zendframework/zend-i18n": "^2.5",


### PR DESCRIPTION
In terms of functionality related to this component, nothing has changed.  However, to ensure that the component works with Expressive RC6, it needs access to the 2.0 release of zend-expressive-helpers.
