### PR TITLE
Work with either zend-expressive-helpers 1.1 or 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": "^5.5 || ^7.0",
         "container-interop/container-interop": "^1.1",
         "psr/http-message": "^1.0",
-        "zendframework/zend-expressive-helpers": "^1.1",
+        "zendframework/zend-expressive-helpers": "^1.1 || ^2.0",
         "zendframework/zend-expressive-template": "^1.0.1",
         "zendframework/zend-filter": "^2.5",
         "zendframework/zend-i18n": "^2.5",


### PR DESCRIPTION
This change allows either major version of zend-expressive-helpers to be installed.
