### PR TITLE
Compatibility with ServiceManager v3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,30 @@ matrix:
   fast_finish: true
   include:
     - php: 5.5
+    - php: 5.5
+      env:
+        - ZEND_SERVICEMANAGER_VERSION="^2.7.5"
     - php: 5.6
       env:
         - EXECUTE_CS_CHECK=true
+    - php: 5.6
+      env:
+        - ZEND_SERVICEMANAGER_VERSION="^2.7.5"
     - php: 7
-    - php: hhvm 
+    - php: 7
+      env:
+        - ZEND_SERVICEMANAGER_VERSION="^2.7.5"
+    - php: hhvm
+    - php: hhvm
+      env:
+        - ZEND_SERVICEMANAGER_VERSION="^2.7.5"
   allow_failures:
     - php: hhvm
 
 before_install:
   - composer self-update
+  - if [[ $ZEND_SERVICEMANAGER_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:$ZEND_SERVICEMANAGER_VERSION" ; fi
+  - if [[ $ZEND_SERVICEMANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0.3" ; fi
 
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs --prefer-source

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "zendframework/zend-expressive-template": "^1.0.1",
         "zendframework/zend-filter": "^2.5",
         "zendframework/zend-i18n": "^2.5",
-        "zendframework/zend-servicemanager": "^2.5",
+        "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
         "zendframework/zend-view": "^2.5"
     },
     "require-dev": {

--- a/src/HelperPluginManagerFactory.php
+++ b/src/HelperPluginManagerFactory.php
@@ -10,7 +10,6 @@
 namespace Zend\Expressive\ZendView;
 
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\Config;
 use Zend\View\HelperPluginManager;
 
 class HelperPluginManagerFactory
@@ -19,8 +18,7 @@ class HelperPluginManagerFactory
     {
         $config = $container->has('config') ? $container->get('config') : [];
         $config = isset($config['view_helpers']) ? $config['view_helpers'] : [];
-        $manager = new HelperPluginManager(new Config($config));
-        $manager->setServiceLocator($container);
+        $manager = new HelperPluginManager($container, $config);
         return $manager;
     }
 }

--- a/src/ServerUrlHelperFactory.php
+++ b/src/ServerUrlHelperFactory.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\ZendView;
+
+use Interop\Container\ContainerInterface;
+use Zend\Expressive\Helper\ServerUrlHelper as BaseServerUrlHelper;
+
+class ServerUrlHelperFactory
+{
+    public function __invoke(ContainerInterface $container)
+    {
+        // test if we are using Zend\ServiceManager v2 or v3
+        if (! method_exists($container, 'configure')) {
+            $container = $container->getServiceLocator();
+        }
+
+        if (!$container->has(BaseServerUrlHelper::class)) {
+            throw new Exception\MissingHelperException(
+                sprintf(
+                    'An instance of %s is required in order to create the "url" view helper; not found',
+                    BaseServerUrlHelper::class
+                )
+            );
+        }
+        return new ServerUrlHelper($container->get(BaseServerUrlHelper::class));
+    }
+}

--- a/src/ServerUrlHelperFactory.php
+++ b/src/ServerUrlHelperFactory.php
@@ -17,7 +17,7 @@ class ServerUrlHelperFactory
     public function __invoke(ContainerInterface $container)
     {
         // test if we are using Zend\ServiceManager v2 or v3
-        if (! method_exists($container, 'configure')) {
+        if (! method_exists($container, 'configure') && method_exists($container, 'getServiceLocator')) {
             $container = $container->getServiceLocator();
         }
 

--- a/src/UrlHelperFactory.php
+++ b/src/UrlHelperFactory.php
@@ -15,7 +15,7 @@ class UrlHelperFactory
     public function __invoke(ContainerInterface $container)
     {
         // test if we are using Zend\ServiceManager v2 or v3
-        if (! method_exists($container, 'configure')) {
+        if (! method_exists($container, 'configure') && method_exists($container, 'getServiceLocator')) {
             $container = $container->getServiceLocator();
         }
 

--- a/src/UrlHelperFactory.php
+++ b/src/UrlHelperFactory.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @see       http://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\ZendView;
+
+use Interop\Container\ContainerInterface;
+use Zend\Expressive\Helper\UrlHelper as BaseUrlHelper;
+
+class UrlHelperFactory
+{
+    public function __invoke(ContainerInterface $container)
+    {
+        // test if we are using Zend\ServiceManager v2 or v3
+        if (! method_exists($container, 'configure')) {
+            $container = $container->getServiceLocator();
+        }
+
+        if (!$container->has(BaseUrlHelper::class)) {
+            throw new Exception\MissingHelperException(
+                sprintf(
+                    'An instance of %s is required in order to create the "url" view helper; not found',
+                    BaseUrlHelper::class
+                )
+            );
+        }
+        return new UrlHelper($container->get(BaseUrlHelper::class));
+    }
+}

--- a/src/ZendViewRendererFactory.php
+++ b/src/ZendViewRendererFactory.php
@@ -10,9 +10,6 @@
 namespace Zend\Expressive\ZendView;
 
 use Interop\Container\ContainerInterface;
-use Zend\Expressive\Helper\ServerUrlHelper as BaseServerUrlHelper;
-use Zend\Expressive\Helper\UrlHelper as BaseUrlHelper;
-use Zend\Expressive\Router\RouterInterface;
 use Zend\View\HelperPluginManager;
 use Zend\View\Renderer\PhpRenderer;
 use Zend\View\Resolver;
@@ -105,15 +102,7 @@ class ZendViewRendererFactory
             : new HelperPluginManager($container);
 
         $helpers->setFactory('url', UrlHelperFactory::class);
-        $helpers->setFactory('serverurl', function () use ($container) {
-            if (! $container->has(BaseServerUrlHelper::class)) {
-                throw new Exception\MissingHelperException(sprintf(
-                    'An instance of %s is required in order to create the "url" view helper; not found',
-                    BaseServerUrlHelper::class
-                ));
-            }
-            return new ServerUrlHelper($container->get(BaseServerUrlHelper::class));
-        });
+        $helpers->setFactory('serverurl', ServerUrlHelperFactory::class);
 
         $renderer->setHelperPluginManager($helpers);
     }

--- a/src/ZendViewRendererFactory.php
+++ b/src/ZendViewRendererFactory.php
@@ -10,6 +10,7 @@
 namespace Zend\Expressive\ZendView;
 
 use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\Config;
 use Zend\View\HelperPluginManager;
 use Zend\View\Renderer\PhpRenderer;
 use Zend\View\Resolver;
@@ -101,8 +102,23 @@ class ZendViewRendererFactory
             ? $container->get(HelperPluginManager::class)
             : new HelperPluginManager($container);
 
-        $helpers->setFactory('url', UrlHelperFactory::class);
-        $helpers->setFactory('serverurl', ServerUrlHelperFactory::class);
+        $config = new Config([
+            'aliases' => [
+                'url' => UrlHelper::class,
+                'Url' => UrlHelper::class,
+                'serverUrl' => ServerUrlHelper::class,
+                'ServerUrl' => ServerUrlHelper::class,
+                'serverurl' => ServerUrlHelper::class,
+            ],
+            'factories' => [
+                UrlHelper::class => UrlHelperFactory::class,
+                ServerUrlHelper::class => ServerUrlHelperFactory::class,
+
+                'zendexpressivezendviewurlhelper' => UrlHelperFactory::class,
+                'zendexpressivezendviewserverurlhelper' => ServerUrlHelperFactory::class,
+            ],
+        ]);
+        $config->configureServiceManager($helpers);
 
         $renderer->setHelperPluginManager($helpers);
     }

--- a/src/ZendViewRendererFactory.php
+++ b/src/ZendViewRendererFactory.php
@@ -102,17 +102,9 @@ class ZendViewRendererFactory
     {
         $helpers = $container->has(HelperPluginManager::class)
             ? $container->get(HelperPluginManager::class)
-            : new HelperPluginManager();
+            : new HelperPluginManager($container);
 
-        $helpers->setFactory('url', function () use ($container) {
-            if (! $container->has(BaseUrlHelper::class)) {
-                throw new Exception\MissingHelperException(sprintf(
-                    'An instance of %s is required in order to create the "url" view helper; not found',
-                    BaseUrlHelper::class
-                ));
-            }
-            return new UrlHelper($container->get(BaseUrlHelper::class));
-        });
+        $helpers->setFactory('url', UrlHelperFactory::class);
         $helpers->setFactory('serverurl', function () use ($container) {
             if (! $container->has(BaseServerUrlHelper::class)) {
                 throw new Exception\MissingHelperException(sprintf(

--- a/test/HelperPluginManagerFactoryTest.php
+++ b/test/HelperPluginManagerFactoryTest.php
@@ -41,7 +41,7 @@ class HelperPluginManagerFactoryTest extends TestCase
     {
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn([]);
-        $factory = new HelperPluginManagerFactory();
+        $factory = new HelperPluginManagerFactory($this->container->reveal());
         $manager = $factory($this->container->reveal());
         $this->assertInstanceOf(HelperPluginManager::class, $manager);
         return $manager;
@@ -59,7 +59,7 @@ class HelperPluginManagerFactoryTest extends TestCase
                 ],
             ]
         );
-        $factory = new HelperPluginManagerFactory();
+        $factory = new HelperPluginManagerFactory($this->container->reveal());
         $manager = $factory($this->container->reveal());
         $this->assertInstanceOf(HelperPluginManager::class, $manager);
         $this->assertTrue($manager->has('testHelper'));

--- a/test/ServerUrlHelperFactoryTest.php
+++ b/test/ServerUrlHelperFactoryTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Expressive\ZendView;
+
+use PHPUnit_Framework_TestCase;
+use Interop\Container\ContainerInterface;
+use Zend\Expressive\Helper\ServerUrlHelper as BaseServerUrlHelper;
+use Zend\Expressive\ZendView\Exception\MissingHelperException;
+use Zend\Expressive\ZendView\ServerUrlHelper;
+use Zend\Expressive\ZendView\ServerUrlHelperFactory;
+use Zend\View\HelperPluginManager;
+
+class ServerUrlHelperFactoryTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    public function setUp()
+    {
+        $this->container = $this->prophesize(ContainerInterface::class);
+    }
+
+    public function testCreatesUrlViewHelper()
+    {
+        $baseHelper = $this->prophesize(BaseServerUrlHelper::class);
+        $this->container->has(BaseServerUrlHelper::class)->willReturn(true);
+        $this->container->get(BaseServerUrlHelper::class)->willReturn($baseHelper->reveal());
+        $helpers = new HelperPluginManager($this->container->reveal());
+        $factory = new ServerUrlHelperFactory();
+        $helper = $factory($helpers);
+        $this->assertInstanceOf(ServerUrlHelper::class, $helper);
+    }
+
+    public function testExceptionIsRisedIfBaseHelperIsNotAvailableInContainer()
+    {
+        $this->container->has(BaseServerUrlHelper::class)->willReturn(false);
+        $helpers = new HelperPluginManager($this->container->reveal());
+        $factory = new ServerUrlHelperFactory();
+        $this->setExpectedException(MissingHelperException::class);
+        $factory($helpers);
+    }
+}

--- a/test/ServerUrlHelperFactoryTest.php
+++ b/test/ServerUrlHelperFactoryTest.php
@@ -10,40 +10,46 @@
 namespace ZendTest\Expressive\ZendView;
 
 use PHPUnit_Framework_TestCase;
-use Interop\Container\ContainerInterface;
 use Zend\Expressive\Helper\ServerUrlHelper as BaseServerUrlHelper;
 use Zend\Expressive\ZendView\Exception\MissingHelperException;
 use Zend\Expressive\ZendView\ServerUrlHelper;
 use Zend\Expressive\ZendView\ServerUrlHelperFactory;
+use Zend\ServiceManager\ServiceManager;
 use Zend\View\HelperPluginManager;
 
 class ServerUrlHelperFactoryTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * @var ContainerInterface
+     * @var ServiceManager
      */
     private $container;
 
     public function setUp()
     {
-        $this->container = $this->prophesize(ContainerInterface::class);
+        $this->container = new ServiceManager();
     }
 
-    public function testCreatesUrlViewHelper()
+    public function testCreatesServerUrlViewHelper()
     {
         $baseHelper = $this->prophesize(BaseServerUrlHelper::class);
-        $this->container->has(BaseServerUrlHelper::class)->willReturn(true);
-        $this->container->get(BaseServerUrlHelper::class)->willReturn($baseHelper->reveal());
-        $helpers = new HelperPluginManager($this->container->reveal());
+        $this->container->setService(BaseServerUrlHelper::class, $baseHelper->reveal());
+        $helpers = new HelperPluginManager($this->container);
         $factory = new ServerUrlHelperFactory();
-        $helper = $factory($helpers);
+
+        // test if we are using Zend\ServiceManager v2 or v3
+        if (! method_exists($helpers, 'configure')) {
+            $container = $helpers;
+        } else {
+            $container = $this->container;
+        }
+
+        $helper = $factory($container);
         $this->assertInstanceOf(ServerUrlHelper::class, $helper);
     }
 
-    public function testExceptionIsRisedIfBaseHelperIsNotAvailableInContainer()
+    public function testExceptionIsRaisedIfBaseHelperIsNotAvailableInContainer()
     {
-        $this->container->has(BaseServerUrlHelper::class)->willReturn(false);
-        $helpers = new HelperPluginManager($this->container->reveal());
+        $helpers = new HelperPluginManager($this->container);
         $factory = new ServerUrlHelperFactory();
         $this->setExpectedException(MissingHelperException::class);
         $factory($helpers);

--- a/test/UrlHelperFactoryTest.php
+++ b/test/UrlHelperFactoryTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Expressive\ZendView;
+
+use PHPUnit_Framework_TestCase;
+use Interop\Container\ContainerInterface;
+use Zend\Expressive\Helper\UrlHelper as BaseUrlHelper;
+use Zend\Expressive\ZendView\Exception\MissingHelperException;
+use Zend\Expressive\ZendView\UrlHelper;
+use Zend\Expressive\ZendView\UrlHelperFactory;
+use Zend\View\HelperPluginManager;
+
+class UrlHelperFactoryTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    public function setUp()
+    {
+        $this->container = $this->prophesize(ContainerInterface::class);
+    }
+
+    public function testCreatesUrlViewHelper()
+    {
+        $baseHelper = $this->prophesize(BaseUrlHelper::class);
+        $this->container->has(BaseUrlHelper::class)->willReturn(true);
+        $this->container->get(BaseUrlHelper::class)->willReturn($baseHelper->reveal());
+        $helpers = new HelperPluginManager($this->container->reveal());
+        $factory = new UrlHelperFactory();
+        $helper = $factory($helpers);
+        $this->assertInstanceOf(UrlHelper::class, $helper);
+    }
+
+    public function testExceptionIsRisedIfBaseHelperIsNotAvailableInContainer()
+    {
+        $this->container->has(BaseUrlHelper::class)->willReturn(false);
+        $helpers = new HelperPluginManager($this->container->reveal());
+        $factory = new UrlHelperFactory();
+        $this->setExpectedException(MissingHelperException::class);
+        $factory($helpers);
+    }
+}

--- a/test/UrlHelperFactoryTest.php
+++ b/test/UrlHelperFactoryTest.php
@@ -10,40 +10,46 @@
 namespace ZendTest\Expressive\ZendView;
 
 use PHPUnit_Framework_TestCase;
-use Interop\Container\ContainerInterface;
 use Zend\Expressive\Helper\UrlHelper as BaseUrlHelper;
 use Zend\Expressive\ZendView\Exception\MissingHelperException;
 use Zend\Expressive\ZendView\UrlHelper;
 use Zend\Expressive\ZendView\UrlHelperFactory;
+use Zend\ServiceManager\ServiceManager;
 use Zend\View\HelperPluginManager;
 
 class UrlHelperFactoryTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * @var ContainerInterface
+     * @var ServiceManager
      */
     private $container;
 
     public function setUp()
     {
-        $this->container = $this->prophesize(ContainerInterface::class);
+        $this->container = new ServiceManager();
     }
 
     public function testCreatesUrlViewHelper()
     {
         $baseHelper = $this->prophesize(BaseUrlHelper::class);
-        $this->container->has(BaseUrlHelper::class)->willReturn(true);
-        $this->container->get(BaseUrlHelper::class)->willReturn($baseHelper->reveal());
-        $helpers = new HelperPluginManager($this->container->reveal());
+        $this->container->setService(BaseUrlHelper::class, $baseHelper->reveal());
+        $helpers = new HelperPluginManager($this->container);
         $factory = new UrlHelperFactory();
-        $helper = $factory($helpers);
+
+        // test if we are using Zend\ServiceManager v2 or v3
+        if (! method_exists($helpers, 'configure')) {
+            $container = $helpers;
+        } else {
+            $container = $this->container;
+        }
+
+        $helper = $factory($container);
         $this->assertInstanceOf(UrlHelper::class, $helper);
     }
 
-    public function testExceptionIsRisedIfBaseHelperIsNotAvailableInContainer()
+    public function testExceptionIsRaisedIfBaseHelperIsNotAvailableInContainer()
     {
-        $this->container->has(BaseUrlHelper::class)->willReturn(false);
-        $helpers = new HelperPluginManager($this->container->reveal());
+        $helpers = new HelperPluginManager($this->container);
         $factory = new UrlHelperFactory();
         $this->setExpectedException(MissingHelperException::class);
         $factory($helpers);

--- a/test/ZendViewRendererFactoryTest.php
+++ b/test/ZendViewRendererFactoryTest.php
@@ -20,6 +20,7 @@ use Zend\Expressive\ZendView\ServerUrlHelper;
 use Zend\Expressive\ZendView\UrlHelper;
 use Zend\Expressive\ZendView\ZendViewRenderer;
 use Zend\Expressive\ZendView\ZendViewRendererFactory;
+use Zend\ServiceManager\ServiceManager;
 use Zend\View\HelperPluginManager;
 use Zend\View\Model\ModelInterface;
 use Zend\View\Resolver\AggregateResolver;

--- a/test/ZendViewRendererFactoryTest.php
+++ b/test/ZendViewRendererFactoryTest.php
@@ -259,7 +259,7 @@ class ZendViewRendererFactoryTest extends TestCase
         $this->container->has('config')->willReturn(false);
         $this->injectBaseHelpers();
 
-        $helpers = new HelperPluginManager();
+        $helpers = new HelperPluginManager($this->container->reveal());
         $this->container->has(HelperPluginManager::class)->willReturn(true);
         $this->container->get(HelperPluginManager::class)->willReturn($helpers);
         $factory = new ZendViewRendererFactory();

--- a/test/ZendViewRendererFactoryTest.php
+++ b/test/ZendViewRendererFactoryTest.php
@@ -247,6 +247,7 @@ class ZendViewRendererFactoryTest extends TestCase
 
         $renderer = $this->fetchPhpRenderer($view);
         $helpers  = $renderer->getHelperPluginManager();
+
         $this->assertInstanceOf(HelperPluginManager::class, $helpers);
         $this->assertTrue($helpers->has('url'));
         $this->assertTrue($helpers->has('serverurl'));


### PR DESCRIPTION
This PR makes updates necessary for this component to work under both Service Manager v2 and v3.

Changes:
- Extracted factories for `UrlHelper` and `ServerUrlHelper` into separate classes.
- Updated required service manager version to `^2.7.5 || ^3.0.3`.
- Updated extracted factories to detect SMv2 and pull dependencies from main service locator:
  
  ``` php
  if (! method_exists($container, 'configure') && method_exists($container, 'getServiceLocator')) {
  $container = $container->getServiceLocator();
    }
  ```
- Updated `ZendViewRendererFactory` to inject view helpers in a way that is compatible with both SMv2 and SMv3.
- Updated Travis test matrix to test with both SMv2 and SMv3
