### PR TITLE
optionally disable layout rendering

### DIFF
--- a/src/ZendViewRenderer.php
+++ b/src/ZendViewRenderer.php
@@ -127,7 +127,10 @@ class ZendViewRenderer implements TemplateRendererInterface
             ? $this->mergeViewModel($name, $params)
             : $this->createModel($name, $params);
 
-        $viewModel = $this->prepareLayout($viewModel);
+        $useLayout = false !== $viewModel->getVariable('layout', null);
+        if ($useLayout) {
+            $viewModel = $this->prepareLayout($viewModel);
+        }
 
         return $this->renderModel($viewModel, $this->renderer);
     }
@@ -319,9 +322,7 @@ class ZendViewRenderer implements TemplateRendererInterface
      */
     private function prepareLayout(ModelInterface $viewModel)
     {
-        $layout = $this->layout ? clone $this->layout : null;
-
-        $providedLayout = $viewModel->getVariable('layout', false);
+        $providedLayout = $viewModel->getVariable('layout', null);
         if (is_string($providedLayout) && ! empty($providedLayout)) {
             $layout = new ViewModel();
             $layout->setTemplate($providedLayout);
@@ -329,6 +330,8 @@ class ZendViewRenderer implements TemplateRendererInterface
         } elseif ($providedLayout instanceof ModelInterface) {
             $layout = $providedLayout;
             $viewModel->setVariable('layout', null);
+        } else {
+            $layout = $this->layout ? clone $this->layout : null;
         }
 
         if ($layout) {

--- a/test/ZendViewRendererTest.php
+++ b/test/ZendViewRendererTest.php
@@ -13,6 +13,7 @@ use ArrayObject;
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Expressive\Template\Exception\InvalidArgumentException;
 use Zend\Expressive\Template\TemplatePath;
+use Zend\Expressive\Template\TemplateRendererInterface;
 use Zend\Expressive\ZendView\ZendViewRenderer;
 use Zend\View\Model\ViewModel;
 use Zend\View\Renderer\PhpRenderer;
@@ -272,6 +273,51 @@ class ZendViewRendererTest extends TestCase
         $content = str_replace('<?php echo $name ?>', $name, $content);
         $this->assertContains($content, $result);
         $this->assertContains('<title>ALTERNATE LAYOUT PAGE</title>', $result);
+    }
+
+    /**
+     * @group layout
+     */
+    public function testDisableLayoutOnRender()
+    {
+        $layout = new ViewModel();
+        $layout->setTemplate('zendview-layout');
+
+        $renderer = new ZendViewRenderer(null, $layout);
+        $renderer->addPath(__DIR__ . '/TestAsset');
+
+        $name = 'zendview';
+        $rendered = $renderer->render('zendview', [
+            'layout' => false,
+            'name'   => $name,
+        ]);
+
+        $expected = file_get_contents(__DIR__ . '/TestAsset/zendview.phtml');
+        $expected = str_replace('<?php echo $name ?>', $name, $expected);
+
+        $this->assertEquals($rendered, $expected);
+    }
+
+    /**
+     * @group layout
+     */
+    public function testDisableLayoutViaDefaultParameter()
+    {
+        $layout = new ViewModel();
+        $layout->setTemplate('zendview-layout');
+
+        $renderer = new ZendViewRenderer(null, $layout);
+        $renderer->addPath(__DIR__ . '/TestAsset');
+        $renderer->addDefaultParam(TemplateRendererInterface::TEMPLATE_ALL, 'layout', false);
+
+
+        $name = 'zendview';
+        $rendered = $renderer->render('zendview', [ 'name' => $name ]);
+
+        $expected = file_get_contents(__DIR__ . '/TestAsset/zendview.phtml');
+        $expected = str_replace('<?php echo $name ?>', $name, $expected);
+
+        $this->assertEquals($rendered, $expected);
     }
 
     /**


### PR DESCRIPTION
I haven't found a way to disable layout rendering other than creating a layout `none.phtml` containing just `<?=$this->content?>`....not very elegant even if it works.

Disabling the layout (`setTerminal(true)` in zend view model terminology) can be useful when handling ajax requests. In most cases I use a JsonResponse, but sometimes an HtmlResponse is needed.

We could use the value `false` for the `$layout` template parameter to make the renderer skip the preparation of layout, because once it's added via its constructor - as far as I know - you can only change it to a different layout.
##### Additional notes:
- i added the layout skipping test inside the `render(...)` method instead of the `prepareLayout(...)` method just to skip a function call.
- I moved the cloning of the injected `$layout` property into the last `else` block. No cloning necessary if providedLayout is used. 
