### PR TITLE
Remove obsolete requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "zendframework/zend-filter": "^2.6.1",
         "zendframework/zend-i18n": "^2.6",
         "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
-        "zendframework/zend-view": "^2.6.5"
+        "zendframework/zend-view": "^2.8.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.7",

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,6 @@
         "psr/http-message": "^1.0",
         "zendframework/zend-expressive-helpers": "^1.1 || ^2.0",
         "zendframework/zend-expressive-template": "^1.0.1",
-        "zendframework/zend-filter": "^2.6.1",
-        "zendframework/zend-i18n": "^2.6",
         "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
         "zendframework/zend-view": "^2.8.1"
     },


### PR DESCRIPTION
zend-filter and zend-i18n are not required anymore. This also prevents the component installer asking questions when creating a new project with the skeleton. Assuming zendframework/zend-expressive-skeleton#54 will be merged.
