### PR TITLE
Ensure $fragmentIdentifier defaults to null

### DIFF
--- a/src/UrlHelper.php
+++ b/src/UrlHelper.php
@@ -28,10 +28,10 @@ class UrlHelper extends AbstractHelper
     /**
      * Proxies to `Zend\Expressive\Helper\UrlHelper::generate()`
      *
-     * @param string $routeName
+     * @param null|string $routeName
      * @param array  $routeParams
      * @param array  $queryParams
-     * @param string $fragmentIdentifier
+     * @param null|string $fragmentIdentifier
      * @param array  $options Can have the following keys:
      *     - router (array): contains options to be passed to the router
      *     - reuse_result_params (bool): indicates if the current RouteResult
@@ -42,7 +42,7 @@ class UrlHelper extends AbstractHelper
         $routeName = null,
         array $routeParams = [],
         array $queryParams = [],
-        $fragmentIdentifier = '',
+        $fragmentIdentifier = null,
         array $options = []
     ) {
         return $this->helper->generate($routeName, $routeParams, $queryParams, $fragmentIdentifier, $options);

--- a/test/UrlHelperTest.php
+++ b/test/UrlHelperTest.php
@@ -25,7 +25,7 @@ class UrlHelperTest extends TestCase
 
     public function testInvocationProxiesToBaseHelper()
     {
-        $this->baseHelper->generate('resource', ['id' => 'sha1'], [], '', [])->willReturn('/resource/sha1');
+        $this->baseHelper->generate('resource', ['id' => 'sha1'], [], null, [])->willReturn('/resource/sha1');
         $helper = $this->createHelper();
         $this->assertEquals('/resource/sha1', $helper('resource', ['id' => 'sha1']));
     }
@@ -43,6 +43,25 @@ class UrlHelperTest extends TestCase
         $this->assertEquals(
             'PATH',
             $helper('resource', ['id' => 'sha1'], ['foo' => 'bar'], 'fragment', ['reuse_result_params' => true])
+        );
+    }
+
+    /**
+     * In particular, the fragment identifier needs to be null.
+     */
+    public function testUrlHelperPassesExpectedDefaultsToBaseHelper()
+    {
+        $this->baseHelper->generate(
+            null,
+            [],
+            [],
+            null,
+            []
+        )->willReturn('PATH');
+        $helper = $this->createHelper();
+        $this->assertEquals(
+            'PATH',
+            $helper()
         );
     }
 }


### PR DESCRIPTION
Prior to this, it defaulted to `''`, which is considered an invalid fragment under zend-expressive-helpers. It should properly default to `null` instead.