### PR TITLE
added files to be ignored during export

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,8 +5,3 @@
 .travis.yml export-ignore
 phpunit.xml.dist export-ignore
 phpcs.xml export-ignore
-.docheader export-ignore
-CONDUCT.md export-ignore
-CONTRIBUTING.md export-ignore
-README.md export-ignore
-CHANGELOG.md export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,8 @@
 .travis.yml export-ignore
 phpunit.xml.dist export-ignore
 phpcs.xml export-ignore
+.docheader export-ignore
+CONDUCT.md export-ignore
+CONTRIBUTING.md export-ignore
+README.md export-ignore
+CHANGELOG.md export-ignore


### PR DESCRIPTION
Additional files to be ignored during export:

- .docheader                                                                                                                                        
- CONDUCT.md                                                                              
- CONTRIBUTING.md
- README.md
- CHANGELOG.md