### PR TITLE
Retrieve the PhpRenderer from the container if it’s there…

### DIFF
--- a/src/ZendViewRendererFactory.php
+++ b/src/ZendViewRendererFactory.php
@@ -62,8 +62,10 @@ class ZendViewRendererFactory
             100
         );
 
-        // Create the renderer
-        $renderer = new PhpRenderer();
+        // Create, or Retrieve the renderer from the container
+        $renderer = ($container->has(PhpRenderer::class))
+                  ? $container->get(PhpRenderer::class)
+                  : new PhpRenderer();
         $renderer->setResolver($resolver);
 
         // Inject helpers

--- a/test/ZendViewRendererFactoryTest.php
+++ b/test/ZendViewRendererFactoryTest.php
@@ -22,6 +22,7 @@ use Zend\View\HelperPluginManager;
 use Zend\View\Model\ModelInterface;
 use Zend\View\Resolver\AggregateResolver;
 use Zend\View\Resolver\TemplateMapResolver;
+use Zend\View\Renderer\PhpRenderer;
 
 class ZendViewRendererFactoryTest extends TestCase
 {
@@ -125,6 +126,7 @@ class ZendViewRendererFactoryTest extends TestCase
     {
         $this->container->has('config')->willReturn(false);
         $this->container->has(HelperPluginManager::class)->willReturn(false);
+        $this->container->has(PhpRenderer::class)->willReturn(false);
         $this->injectBaseHelpers();
         $factory = new ZendViewRendererFactory();
         $view    = $factory($this->container->reveal());
@@ -154,6 +156,7 @@ class ZendViewRendererFactoryTest extends TestCase
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn($config);
         $this->container->has(HelperPluginManager::class)->willReturn(false);
+        $this->container->has(PhpRenderer::class)->willReturn(false);
         $this->injectBaseHelpers();
         $factory = new ZendViewRendererFactory();
         $view = $factory($this->container->reveal());
@@ -175,6 +178,7 @@ class ZendViewRendererFactoryTest extends TestCase
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn($config);
         $this->container->has(HelperPluginManager::class)->willReturn(false);
+        $this->container->has(PhpRenderer::class)->willReturn(false);
         $this->injectBaseHelpers();
         $factory = new ZendViewRendererFactory();
         $view = $factory($this->container->reveal());
@@ -212,6 +216,7 @@ class ZendViewRendererFactoryTest extends TestCase
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn($config);
         $this->container->has(HelperPluginManager::class)->willReturn(false);
+        $this->container->has(PhpRenderer::class)->willReturn(false);
         $this->injectBaseHelpers();
         $factory = new ZendViewRendererFactory();
         $view = $factory($this->container->reveal());
@@ -238,6 +243,7 @@ class ZendViewRendererFactoryTest extends TestCase
     {
         $this->container->has('config')->willReturn(false);
         $this->container->has(HelperPluginManager::class)->willReturn(false);
+        $this->container->has(PhpRenderer::class)->willReturn(false);
         $this->injectBaseHelpers();
         $factory = new ZendViewRendererFactory();
         $view    = $factory($this->container->reveal());
@@ -255,6 +261,7 @@ class ZendViewRendererFactoryTest extends TestCase
     public function testWillUseHelperManagerFromContainer()
     {
         $this->container->has('config')->willReturn(false);
+        $this->container->has(PhpRenderer::class)->willReturn(false);
         $this->injectBaseHelpers();
 
         $helpers = new HelperPluginManager($this->container->reveal());
@@ -280,5 +287,19 @@ class ZendViewRendererFactoryTest extends TestCase
         $this->assertTrue($helpers->has('serverurl'));
         $this->assertInstanceOf(UrlHelper::class, $helpers->get('url'));
         $this->assertInstanceOf(ServerUrlHelper::class, $helpers->get('serverurl'));
+    }
+
+    public function testWillUseRendererFromContainer()
+    {
+        $engine = new PhpRenderer;
+        $this->container->has('config')->willReturn(false);
+        $this->container->has(HelperPluginManager::class)->willReturn(false);
+        $this->injectContainerService(PhpRenderer::class, $engine);
+
+        $factory = new ZendViewRendererFactory();
+        $view = $factory($this->container->reveal());
+
+        $composed = $this->fetchPhpRenderer($view);
+        $this->assertSame($engine, $composed);
     }
 }


### PR DESCRIPTION
If you want to attach filters to the rendering engine filter chain for example, it’s not possible to access it from `ZendViewRenderer` so the factory is altered to retrieve a PhpRenderer from the container if one exists