### PR TITLE
Shared default params available in layout

### DIFF
--- a/src/ZendViewRenderer.php
+++ b/src/ZendViewRenderer.php
@@ -339,6 +339,7 @@ class ZendViewRenderer implements TemplateRendererInterface
         if ($layout) {
             $layout->addChild($viewModel);
             $viewModel = $layout;
+            $viewModel->setVariables($this->mergeParams(self::TEMPLATE_ALL, []));
         }
 
         return $viewModel;

--- a/test/TestAsset/zendview-layout-variable.phtml
+++ b/test/TestAsset/zendview-layout-variable.phtml
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Layout Page: <?= $this->title ?></title>
+</head>
+<body>
+    <?= $this->content ?>
+</body>

--- a/test/ZendViewRendererTest.php
+++ b/test/ZendViewRendererTest.php
@@ -208,6 +208,44 @@ class ZendViewRendererTest extends TestCase
         $this->assertContains('<title>Layout Page</title>', $result, sprintf('Received %s', $result));
     }
 
+    public function testSharedParameterIsAvailableInLayout()
+    {
+        $renderer = new ZendViewRenderer(null, 'zendview-layout-variable');
+        $renderer->addPath(__DIR__ . '/TestAsset');
+        $title = uniqid('ZendViewTitle', true);
+        $renderer->addDefaultParam($renderer::TEMPLATE_ALL, 'title', $title);
+
+        $name = uniqid('ZendViewName', true);
+        $result = $renderer->render('zendview', ['name' => $name]);
+
+        $this->assertContains($title, $result);
+        $this->assertContains($name, $result);
+        $content = file_get_contents(__DIR__ . '/TestAsset/zendview.phtml');
+        $content = str_replace('<?php echo $name ?>', $name, $content);
+        $this->assertContains($content, $result);
+        $expected = sprintf('<title>Layout Page: %s</title>', $title);
+        $this->assertContains($expected, $result, sprintf('Received %s', $result));
+    }
+
+    public function testTemplateDefaultParameterIsNotAvailableInLayout()
+    {
+        $renderer = new ZendViewRenderer(null, 'zendview-layout-variable');
+        $renderer->addPath(__DIR__ . '/TestAsset');
+        $title = uniqid('ZendViewTitle', true);
+        $renderer->addDefaultParam('zendview', 'title', $title);
+
+        $name = uniqid('ZendViewName', true);
+        $result = $renderer->render('zendview', ['name' => $name]);
+
+        $this->assertNotContains($title, $result);
+        $this->assertContains($name, $result);
+        $content = file_get_contents(__DIR__ . '/TestAsset/zendview.phtml');
+        $content = str_replace('<?php echo $name ?>', $name, $content);
+        $this->assertContains($content, $result);
+        $expected = sprintf('<title>Layout Page: %s</title>', '');
+        $this->assertContains($expected, $result, sprintf('Received %s', $result));
+    }
+
     /**
      * @group layout
      */


### PR DESCRIPTION
I think shared default parameters should be available in layout.
Currently these are available only in template. I know that we can access them using:
```php
$child = $this->viewModel()->getCurrent()->getChildren()[0];
echo $child->variableFromTemplate;
```
but it is not convenient at all... 

I can't see any other way currently to set some layout params. Am I missing something?

The other solution for me will be possibility to set variables only for view, something like:
```php
$renderer->addDefaultParam('layout-name', 'param-name', 'param-value');
```

Or maybe we should have both?
Shared variables visible in layout directly (as I have done in PR) and possibility to set variables only for layout?