### PR TITLE
mergeViewModel pass array instead of object to mergeParams function

### DIFF
--- a/src/ZendViewRenderer.php
+++ b/src/ZendViewRenderer.php
@@ -295,7 +295,8 @@ class ZendViewRenderer implements TemplateRendererInterface
      */
     private function mergeViewModel($name, ModelInterface $model)
     {
-        $params = $this->mergeParams($name, $model->getVariables());
+        $variables = $model->getVariables();
+        $params = $this->mergeParams($name, $this->normalizeParams($variables));
         $model->setVariables($params);
         $model->setTemplate($name);
         return $model;

--- a/test/ZendViewRendererTest.php
+++ b/test/ZendViewRendererTest.php
@@ -430,4 +430,27 @@ class ZendViewRendererTest extends TestCase
         $content = str_replace('<?php echo $name ?>', 'Zend', $content);
         $this->assertEquals($content, $result);
     }
+    
+    public function testCanRenderWithChildViewModel()
+    {
+        $path = __DIR__ . '/TestAsset';
+        $renderer = new ZendViewRenderer();
+        $renderer->addPath($path);
+        $viewModelParent = new ViewModel();
+        $viewModelChild = new ViewModel();
+        $viewModelChild->setTemplate('zendview-null');
+        $viewModelParent->setVariables([
+                'layout' => 'zendview-layout',
+        ]);
+        $viewModelParent->addChild($viewModelChild, 'name');
+        $result = $renderer->render('zendview', $viewModelParent);
+        
+        $content = file_get_contents("$path/zendview-null.phtml");
+        $contentParent = file_get_contents("$path/zendview.phtml");
+        $contentParentLayout = file_get_contents("$path/zendview-layout.phtml");
+        //trim is used here, because rendering engine is trimming content too 
+        $content = trim(str_replace('<?php echo $name ?>', $content, $contentParent));
+        $content = str_replace('<?= $this->content ?>', $content, $contentParentLayout);
+        $this->assertEquals($content, $result);
+    }
 }

--- a/test/ZendViewRendererTest.php
+++ b/test/ZendViewRendererTest.php
@@ -444,11 +444,11 @@ class ZendViewRendererTest extends TestCase
         ]);
         $viewModelParent->addChild($viewModelChild, 'name');
         $result = $renderer->render('zendview', $viewModelParent);
-        
+
         $content = file_get_contents("$path/zendview-null.phtml");
         $contentParent = file_get_contents("$path/zendview.phtml");
         $contentParentLayout = file_get_contents("$path/zendview-layout.phtml");
-        //trim is used here, because rendering engine is trimming content too 
+        //trim is used here, because rendering engine is trimming content too
         $content = trim(str_replace('<?php echo $name ?>', $content, $contentParent));
         $content = str_replace('<?= $this->content ?>', $content, $contentParentLayout);
         $this->assertEquals($content, $result);

--- a/test/ZendViewRendererTest.php
+++ b/test/ZendViewRendererTest.php
@@ -430,7 +430,7 @@ class ZendViewRendererTest extends TestCase
         $content = str_replace('<?php echo $name ?>', 'Zend', $content);
         $this->assertEquals($content, $result);
     }
-    
+
     public function testCanRenderWithChildViewModel()
     {
         $path = __DIR__ . '/TestAsset';


### PR DESCRIPTION
Currently when you create new view mode - the parameters are passed as object, so Zend\Expressive\Template\DefaultParamsTrait
private function mergeParams($template, array $params)
return array_replace_recursive($globalDefaults, $templateDefaults, $params);

returns NULL, which breaks the script.