### PR TITLE
Provide PHP 7.1 support

### DIFF
--- a/.docheader
+++ b/.docheader
@@ -1,5 +1,7 @@
 /**
  * @see       https://github.com/zendframework/zend-expressive-zendviewrenderer for the canonical source repository
- * @copyright Copyright (c) %regexp:(20\d{2}-)?20\d{2}% Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) %regexp:(20\d{2}-)?20\d{2}% Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-zendviewrenderer/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
 
 install:
-  - travis_retry composer install $COMPOSER_ARGS --ignore-platform-reqs
+  - travis_retry composer install $COMPOSER_ARGS
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
   - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
   - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $COVERAGE_DEPS ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,46 +13,6 @@ env:
 
 matrix:
   include:
-    - php: 5.6
-      env:
-        - DEPS=lowest
-    - php: 5.6
-      env:
-        - DEPS=locked
-        - LEGACY_DEPS="phpunit/phpunit"
-    - php: 5.6
-      env:
-        - DEPS=locked
-        - LEGACY_DEPS="phpunit/phpunit"
-        - HELPER_DEPS="zendframework/zend-expressive-helpers:^2.2 zendframework/zend-expressive-router:^1.3.2"
-    - php: 5.6
-      env:
-        - DEPS=locked
-        - LEGACY_DEPS="phpunit/phpunit"
-        - HELPER_DEPS="zendframework/zend-expressive-helpers:^3.0.1"
-    - php: 5.6
-      env:
-        - DEPS=latest
-    - php: 7
-      env:
-        - DEPS=lowest
-    - php: 7
-      env:
-        - DEPS=locked
-        - LEGACY_DEPS="phpunit/phpunit"
-    - php: 7
-      env:
-        - DEPS=locked
-        - LEGACY_DEPS="phpunit/phpunit"
-        - HELPER_DEPS="zendframework/zend-expressive-helpers:^2.2 zendframework/zend-expressive-router:^1.3.2"
-    - php: 7
-      env:
-        - DEPS=locked
-        - LEGACY_DEPS="phpunit/phpunit"
-        - HELPER_DEPS="zendframework/zend-expressive-helpers:^3.0.1"
-    - php: 7
-      env:
-        - DEPS=latest
     - php: 7.1
       env:
         - DEPS=lowest
@@ -63,14 +23,6 @@ matrix:
         - TEST_COVERAGE=true
     - php: 7.1
       env:
-        - DEPS=locked
-        - HELPER_DEPS="zendframework/zend-expressive-helpers:^2.2 zendframework/zend-expressive-router:^1.3.2"
-    - php: 7.1
-      env:
-        - DEPS=locked
-        - HELPER_DEPS="zendframework/zend-expressive-helpers:^3.0.1"
-    - php: 7.1
-      env:
         - DEPS=latest
     - php: 7.2
       env:
@@ -80,14 +32,6 @@ matrix:
         - DEPS=locked
     - php: 7.2
       env:
-        - DEPS=locked
-        - HELPER_DEPS="zendframework/zend-expressive-helpers:^2.2 zendframework/zend-expressive-router:^1.3.2"
-    - php: 7.2
-      env:
-        - DEPS=locked
-        - HELPER_DEPS="zendframework/zend-expressive-helpers:^3.0.1"
-    - php: 7.2
-      env:
         - DEPS=latest
 
 before_install:
@@ -95,10 +39,8 @@ before_install:
 
 install:
   - travis_retry composer install $COMPOSER_ARGS --ignore-platform-reqs
-  - if [[ $LEGACY_DEPS != '' ]]; then travis_retry composer update $COMPOSER_ARGS --with-dependencies $LEGACY_DEPS ; fi
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
   - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
-  - if [[ $HELPER_DEPS != '' ]]; then travis_retry composer require $COMPOSER_ARGS --update-with-dependencies $HELPER_DEPS ; fi
   - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $COVERAGE_DEPS ; fi
   - stty cols 120 && composer show
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- [#46](https://github.com/zendframework/zend-expressive-zendviewrenderer/pull/46)
+  adds support for the zend-expressive-template v2 series,
+  zend-expressive-router v3 series, and zend-expressive-helpers v5 series.
 
 ### Changed
 
@@ -15,13 +17,28 @@ All notable changes to this project will be documented in this file, in reverse 
   container-interop exceptions now extend from PSR-11 exception interfaces,
   and factories typehint against the PSR-11 `ContainerInterface`.
 
+- [#46](https://github.com/zendframework/zend-expressive-zendviewrenderer/pull/46)
+  updates all classes to use scalar and return type hints, including nullable
+  and void types. If you were extending classes from this package, you may need
+  to update signatures of methods you override.
+
 ### Deprecated
 
 - Nothing.
 
 ### Removed
 
-- Nothing.
+- [#46](https://github.com/zendframework/zend-expressive-zendviewrenderer/pull/46)
+  removes support for PHP versions prior to PHP 7.1.
+
+- [#46](https://github.com/zendframework/zend-expressive-zendviewrenderer/pull/46)
+  removes support for zend-expressive-template versions prior to v2.
+
+- [#46](https://github.com/zendframework/zend-expressive-zendviewrenderer/pull/46)
+  removes support for zend-expressive-router versions prior to v3.
+
+- [#46](https://github.com/zendframework/zend-expressive-zendviewrenderer/pull/46)
+  removes support for zend-expressive-helpers versions prior to v5.
 
 ### Fixed
 

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     },
     "require-dev": {
         "malukenho/docheader": "^0.1.5",
-        "phpunit/phpunit": "^6.5.3",
+        "phpunit/phpunit": "^6.5.4",
         "zendframework/zend-coding-standard": "~1.0.0"
     },
     "conflict": {

--- a/composer.json
+++ b/composer.json
@@ -20,19 +20,18 @@
         "forum": "https://discourse.zendframework.com/c/questions/expressive"
     },
     "require": {
-        "php": "^5.6 || ^7.0",
-        "container-interop/container-interop": "^1.2.0",
+        "php": "^7.1",
         "psr/container": "^1.0",
         "psr/http-message": "^1.0.1",
-        "zendframework/zend-expressive-helpers": "^1.4 || ^2.2 || ^3.0.1 || ^4.0",
-        "zendframework/zend-expressive-router": "^1.3.2 || ^2.1",
-        "zendframework/zend-expressive-template": "^1.0.4",
+        "zendframework/zend-expressive-helpers": "^5.0.0-dev",
+        "zendframework/zend-expressive-router": "^3.0.0-dev",
+        "zendframework/zend-expressive-template": "^2.0.0-dev",
         "zendframework/zend-servicemanager": "^2.7.8 || ^3.3",
         "zendframework/zend-view": "^2.8.1"
     },
     "require-dev": {
         "malukenho/docheader": "^0.1.5",
-        "phpunit/phpunit": "^5.7.23 || ^6.4.3",
+        "phpunit/phpunit": "^6.5.3",
         "zendframework/zend-coding-standard": "~1.0.0"
     },
     "conflict": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "3d986d7dbb955f33e3f5f7ba87502e94",
+    "content-hash": "5db33febc7f5117daf2f5733aeda55d1",
     "packages": [
         {
             "name": "container-interop/container-interop",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "5abb1d1cfcdde1afe0c0c0460b7579aa",
+    "content-hash": "3d986d7dbb955f33e3f5f7ba87502e94",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -88,22 +88,78 @@
             "time": "2017-02-09T16:10:21+00:00"
         },
         {
-            "name": "http-interop/http-middleware",
-            "version": "0.5.0",
+            "name": "http-interop/http-server-handler",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/http-interop/http-middleware.git",
-                "reference": "b49e1f9f6c584e704317b563302e566b8ce11858"
+                "url": "https://github.com/http-interop/http-server-handler.git",
+                "reference": "931a6495fb1b6005c9b4abc4dd11fb12a2a8103b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/http-interop/http-middleware/zipball/b49e1f9f6c584e704317b563302e566b8ce11858",
-                "reference": "b49e1f9f6c584e704317b563302e566b8ce11858",
+                "url": "https://api.github.com/repos/http-interop/http-server-handler/zipball/931a6495fb1b6005c9b4abc4dd11fb12a2a8103b",
+                "reference": "931a6495fb1b6005c9b4abc4dd11fb12a2a8103b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0",
+                "php": ">=7.0",
                 "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Interop\\Http\\Server\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP server-side request handler",
+            "keywords": [
+                "handler",
+                "http",
+                "psr",
+                "psr-15",
+                "psr-7",
+                "request",
+                "response",
+                "server"
+            ],
+            "time": "2017-11-09T18:35:22+00:00"
+        },
+        {
+            "name": "http-interop/http-server-middleware",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/http-interop/http-server-middleware.git",
+                "reference": "e605a7f47a002e857a3b9bb992010e2f859e4560"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/http-interop/http-server-middleware/zipball/e605a7f47a002e857a3b9bb992010e2f859e4560",
+                "reference": "e605a7f47a002e857a3b9bb992010e2f859e4560",
+                "shasum": ""
+            },
+            "require": {
+                "http-interop/http-server-handler": "^1.0",
+                "php": ">=7.0",
+                "psr/http-message": "^1.0"
+            },
+            "replace": {
+                "http-interop/http-middleware": ">=0.5"
             },
             "type": "library",
             "extra": {
@@ -136,8 +192,7 @@
                 "request",
                 "response"
             ],
-            "abandoned": "http-interop/http-server-middleware",
-            "time": "2017-09-18T15:27:03+00:00"
+            "time": "2017-11-09T21:42:30+00:00"
         },
         {
             "name": "psr/container",
@@ -239,98 +294,6 @@
             "time": "2016-08-06T14:39:51+00:00"
         },
         {
-            "name": "webimpress/composer-extra-dependency",
-            "version": "0.2.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webimpress/composer-extra-dependency.git",
-                "reference": "31fa56391d30f03b1180c87610cbe22254780ad9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webimpress/composer-extra-dependency/zipball/31fa56391d30f03b1180c87610cbe22254780ad9",
-                "reference": "31fa56391d30f03b1180c87610cbe22254780ad9",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^1.1",
-                "php": "^5.6 || ^7.0"
-            },
-            "require-dev": {
-                "composer/composer": "^1.5.2",
-                "mikey179/vfsstream": "^1.6.5",
-                "phpunit/phpunit": "^5.7.22 || ^6.4.1",
-                "zendframework/zend-coding-standard": "~1.0.0"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "Webimpress\\ComposerExtraDependency\\Plugin"
-            },
-            "autoload": {
-                "psr-4": {
-                    "Webimpress\\ComposerExtraDependency\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-2-Clause"
-            ],
-            "description": "Composer plugin to require extra dependencies",
-            "homepage": "https://github.com/webimpress/composer-extra-dependency",
-            "keywords": [
-                "composer",
-                "dependency",
-                "webimpress"
-            ],
-            "time": "2017-10-17T17:15:14+00:00"
-        },
-        {
-            "name": "webimpress/http-middleware-compatibility",
-            "version": "0.1.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webimpress/http-middleware-compatibility.git",
-                "reference": "8ed1c2c7523dce0035b98bc4f3a73ca9cd1d3717"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webimpress/http-middleware-compatibility/zipball/8ed1c2c7523dce0035b98bc4f3a73ca9cd1d3717",
-                "reference": "8ed1c2c7523dce0035b98bc4f3a73ca9cd1d3717",
-                "shasum": ""
-            },
-            "require": {
-                "http-interop/http-middleware": "^0.1.1 || ^0.2 || ^0.3 || ^0.4.1 || ^0.5",
-                "php": "^5.6 || ^7.0",
-                "webimpress/composer-extra-dependency": "^0.2.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^5.7.23 || ^6.4.3"
-            },
-            "type": "library",
-            "extra": {
-                "dependency": [
-                    "http-interop/http-middleware"
-                ]
-            },
-            "autoload": {
-                "files": [
-                    "autoload/http-middleware.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-2-Clause"
-            ],
-            "description": "Compatibility library for Draft PSR-15 HTTP Middleware",
-            "homepage": "https://github.com/webimpress/http-middleware-compatibility",
-            "keywords": [
-                "middleware",
-                "psr-15",
-                "webimpress"
-            ],
-            "time": "2017-10-17T17:31:10+00:00"
-        },
-        {
             "name": "zendframework/zend-eventmanager",
             "version": "3.2.0",
             "source": {
@@ -386,29 +349,29 @@
         },
         {
             "name": "zendframework/zend-expressive-helpers",
-            "version": "4.2.0",
+            "version": "dev-release-5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-expressive-helpers.git",
-                "reference": "137d863d4741210d05297b4bb1c30264f100ba8f"
+                "reference": "7ae6386c545bcad4edd9ab7b644c0924521d6009"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-helpers/zipball/137d863d4741210d05297b4bb1c30264f100ba8f",
-                "reference": "137d863d4741210d05297b4bb1c30264f100ba8f",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-helpers/zipball/7ae6386c545bcad4edd9ab7b644c0924521d6009",
+                "reference": "7ae6386c545bcad4edd9ab7b644c0924521d6009",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0",
+                "http-interop/http-server-middleware": "^1.0.1",
+                "php": "^7.1",
                 "psr/container": "^1.0",
                 "psr/http-message": "^1.0.1",
-                "webimpress/http-middleware-compatibility": "^0.1.1",
-                "zendframework/zend-expressive-router": "^2.2"
+                "zendframework/zend-expressive-router": "^3.0.0@dev"
             },
             "require-dev": {
                 "malukenho/docheader": "^0.1.5",
                 "mockery/mockery": "^1.0",
-                "phpunit/phpunit": "^5.7.22 || ^6.4.1",
+                "phpunit/phpunit": "^6.4.4",
                 "zendframework/zend-coding-standard": "~1.0.0",
                 "zendframework/zend-diactoros": "^1.3.10"
             },
@@ -420,8 +383,9 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev",
-                    "dev-develop": "4.3-dev"
+                    "dev-master": "4.2.x-dev",
+                    "dev-develop": "4.3.x-dev",
+                    "dev-release-5.0.0": "5.0.x-dev"
                 }
             },
             "autoload": {
@@ -441,31 +405,31 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2017-10-09T19:03:01+00:00"
+            "time": "2017-12-07T20:18:55+00:00"
         },
         {
             "name": "zendframework/zend-expressive-router",
-            "version": "2.2.0",
+            "version": "dev-release-3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-expressive-router.git",
-                "reference": "f6eac53d39cdbf7b6db11b3e6bb3565896633de4"
+                "reference": "57ebf529def0743ab9e781040e2a3c5b5aeb7533"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/f6eac53d39cdbf7b6db11b3e6bb3565896633de4",
-                "reference": "f6eac53d39cdbf7b6db11b3e6bb3565896633de4",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/57ebf529def0743ab9e781040e2a3c5b5aeb7533",
+                "reference": "57ebf529def0743ab9e781040e2a3c5b5aeb7533",
                 "shasum": ""
             },
             "require": {
                 "fig/http-message-util": "^1.1.2",
-                "php": "^5.6 || ^7.0",
-                "psr/http-message": "^1.0.1",
-                "webimpress/http-middleware-compatibility": "^0.1.1"
+                "http-interop/http-server-middleware": "^1.0.1",
+                "php": "^7.1",
+                "psr/http-message": "^1.0.1"
             },
             "require-dev": {
                 "malukenho/docheader": "^0.1.5",
-                "phpunit/phpunit": "^6.0.8 || ^5.7.15",
+                "phpunit/phpunit": "^6.4.4",
                 "zendframework/zend-coding-standard": "~1.0.0"
             },
             "suggest": {
@@ -476,8 +440,9 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2-dev",
-                    "dev-develop": "2.3-dev"
+                    "dev-master": "2.2.x-dev",
+                    "dev-develop": "2.3.x-dev",
+                    "dev-release-3.0.0": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -491,45 +456,50 @@
             ],
             "description": "Router subcomponent for Expressive",
             "keywords": [
+                "ZendFramework",
                 "expressive",
                 "http",
                 "middleware",
                 "psr",
-                "psr-7"
+                "psr-7",
+                "zend-expressive",
+                "zf"
             ],
-            "time": "2017-10-09T18:44:11+00:00"
+            "time": "2017-12-07T17:39:11+00:00"
         },
         {
             "name": "zendframework/zend-expressive-template",
-            "version": "1.0.4",
+            "version": "dev-release-2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-expressive-template.git",
-                "reference": "23922f96b32ab6e64fc551ec06b81fd047828765"
+                "reference": "49a19cfe466e8462beed87c3b1e3d307cf632139"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-template/zipball/23922f96b32ab6e64fc551ec06b81fd047828765",
-                "reference": "23922f96b32ab6e64fc551ec06b81fd047828765",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-template/zipball/49a19cfe466e8462beed87c3b1e3d307cf632139",
+                "reference": "49a19cfe466e8462beed87c3b1e3d307cf632139",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.7",
+                "malukenho/docheader": "^0.1.6",
+                "phpunit/phpunit": "^6.5.3",
                 "zendframework/zend-coding-standard": "~1.0.0"
             },
             "suggest": {
-                "zendframework/zend-expressive-platesrenderer": "^0.1 to use the Plates template renderer",
-                "zendframework/zend-expressive-twigrenderer": "^0.1 to use the Twig template renderer",
-                "zendframework/zend-expressive-zendviewrenderer": "^0.1 to use the zend-view PhpRenderer template renderer"
+                "zendframework/zend-expressive-platesrenderer": "^2.0 to use the Plates template renderer",
+                "zendframework/zend-expressive-twigrenderer": "^2.0 to use the Twig template renderer",
+                "zendframework/zend-expressive-zendviewrenderer": "^2.0 to use the zend-view PhpRenderer template renderer"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev",
-                    "dev-develop": "1.1-dev"
+                    "dev-master": "1.0.x-dev",
+                    "dev-develop": "1.1.x-dev",
+                    "dev-release-2.0.0": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -543,10 +513,13 @@
             ],
             "description": "Template subcomponent for Expressive",
             "keywords": [
+                "ZendFramework",
                 "expressive",
-                "template"
+                "template",
+                "zend-expressive",
+                "zf"
             ],
-            "time": "2017-01-11T18:42:34+00:00"
+            "time": "2017-12-12T16:17:11+00:00"
         },
         {
             "name": "zendframework/zend-loader",
@@ -2687,11 +2660,15 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "zendframework/zend-expressive-helpers": 20,
+        "zendframework/zend-expressive-router": 20,
+        "zendframework/zend-expressive-template": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^5.6 || ^7.0"
+        "php": "^7.1"
     },
     "platform-dev": []
 }

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-zendviewrenderer for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-zendviewrenderer/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Expressive\ZendView\Exception;
 

--- a/src/Exception/InvalidContainerException.php
+++ b/src/Exception/InvalidContainerException.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-zendviewrenderer for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-zendviewrenderer/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\ZendView\Exception;
+
+use RuntimeException;
+
+class InvalidContainerException extends RuntimeException implements ExceptionInterface
+{
+}

--- a/src/Exception/MissingHelperException.php
+++ b/src/Exception/MissingHelperException.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-zendviewrenderer for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-zendviewrenderer/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Expressive\ZendView\Exception;
 

--- a/src/HelperPluginManagerFactory.php
+++ b/src/HelperPluginManagerFactory.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-zendviewrenderer for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-zendviewrenderer/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Expressive\ZendView;
 
@@ -13,7 +15,7 @@ use Zend\View\HelperPluginManager;
 
 class HelperPluginManagerFactory
 {
-    public function __invoke(ContainerInterface $container)
+    public function __invoke(ContainerInterface $container) : HelperPluginManager
     {
         $manager = new HelperPluginManager($container);
 

--- a/src/NamespacedPathStackResolver.php
+++ b/src/NamespacedPathStackResolver.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-zendviewrenderer for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-zendviewrenderer/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Expressive\ZendView;
 
@@ -39,10 +41,8 @@ class NamespacedPathStackResolver extends TemplatePathStack
      *
      * Overrides parent constructor to allow specifying paths as an associative
      * array.
-     *
-     * @param null|array|Traversable $options
      */
-    public function __construct($options = null)
+    public function __construct(iterable $options = null)
     {
         $this->useViewStream = (bool) ini_get('short_open_tag');
         if ($this->useViewStream) {
@@ -60,12 +60,10 @@ class NamespacedPathStackResolver extends TemplatePathStack
      * Add a path to the stack with the given namespace.
      *
      * @param string $path
-     * @param string $namespace
-     * @return void
      * @throws ViewException\InvalidArgumentException for an invalid path
      * @throws ViewException\InvalidArgumentException for an invalid namespace
      */
-    public function addPath($path, $namespace = self::DEFAULT_NAMESPACE)
+    public function addPath($path, ?string $namespace = self::DEFAULT_NAMESPACE) : void
     {
         if (! is_string($path)) {
             throw new ViewException\InvalidArgumentException(sprintf(
@@ -93,11 +91,8 @@ class NamespacedPathStackResolver extends TemplatePathStack
 
     /**
      * Add many paths to the stack at once.
-     *
-     * @param array $paths
-     * @return void
      */
-    public function addPaths(array $paths)
+    public function addPaths(array $paths) : void
     {
         foreach ($paths as $namespace => $path) {
             if (! is_string($namespace)) {
@@ -111,11 +106,10 @@ class NamespacedPathStackResolver extends TemplatePathStack
     /**
      * Overwrite all existing paths with the provided paths.
      *
-     * @param array|Traversable $paths
-     * @return void
+     * @param  SplStack|array $paths
      * @throws ViewException\InvalidArgumentException for invalid path types.
      */
-    public function setPaths($paths)
+    public function setPaths($paths) : void
     {
         if ($paths instanceof Traversable) {
             $paths = iterator_to_array($paths);
@@ -134,10 +128,8 @@ class NamespacedPathStackResolver extends TemplatePathStack
 
     /**
      * Clear all paths.
-     *
-     * @return void
      */
-    public function clearPaths()
+    public function clearPaths() : void
     {
         $this->paths = [];
     }
@@ -146,11 +138,9 @@ class NamespacedPathStackResolver extends TemplatePathStack
      * Retrieve the filesystem path to a view script
      *
      * @param string $name
-     * @param null|RendererInterface $renderer
-     * @return false|string
      * @throws ViewException\DomainException
      */
-    public function resolve($name, RendererInterface $renderer = null)
+    public function resolve($name, RendererInterface $renderer = null) : ?string
     {
         $namespace = self::DEFAULT_NAMESPACE;
         $template  = $name;
@@ -169,7 +159,7 @@ class NamespacedPathStackResolver extends TemplatePathStack
 
         if (! count($this->paths)) {
             $this->lastLookupFailure = static::FAILURE_NO_PATHS;
-            return false;
+            return null;
         }
 
         // Ensure we have the expected file extension
@@ -190,20 +180,18 @@ class NamespacedPathStackResolver extends TemplatePathStack
         }
 
         $this->lastLookupFailure = static::FAILURE_NOT_FOUND;
-        return false;
+        return null;
     }
 
     /**
      * Fetch a template path from a given namespace.
      *
-     * @param string $template
-     * @param string $namespace
-     * @return false|string String path on success; false on failure
+     * @return null|string String path on success; null on failure
      */
-    private function getPathFromNamespace($template, $namespace)
+    private function getPathFromNamespace(string $template, string $namespace) : ?string
     {
         if (! array_key_exists($namespace, $this->paths)) {
-            return false;
+            return null;
         }
 
         foreach ($this->paths[$namespace] as $path) {
@@ -226,6 +214,6 @@ class NamespacedPathStackResolver extends TemplatePathStack
             }
         }
 
-        return false;
+        return null;
     }
 }

--- a/src/NamespacedPathStackResolver.php
+++ b/src/NamespacedPathStackResolver.php
@@ -29,7 +29,7 @@ use Zend\View\Resolver\TemplatePathStack;
  */
 class NamespacedPathStackResolver extends TemplatePathStack
 {
-    const DEFAULT_NAMESPACE = '__DEFAULT__';
+    public const DEFAULT_NAMESPACE = '__DEFAULT__';
 
     /**
      * @var array

--- a/src/ServerUrlHelper.php
+++ b/src/ServerUrlHelper.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-zendviewrenderer for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-zendviewrenderer/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Expressive\ZendView;
 
@@ -21,9 +23,6 @@ class ServerUrlHelper extends AbstractHelper
      */
     private $helper;
 
-    /**
-     * @param BaseHelper $helper
-     */
     public function __construct(BaseHelper $helper)
     {
         $this->helper = $helper;
@@ -33,21 +32,16 @@ class ServerUrlHelper extends AbstractHelper
      * Return a path relative to the current request URI.
      *
      * Proxies to `Zend\Expressive\Helper\ServerUrlHelper::generate()`.
-     *
-     * @param null|string $path
-     * @return string
      */
-    public function __invoke($path = null)
+    public function __invoke(?string $path = null) : string
     {
         return $this->helper->generate($path);
     }
 
     /**
      * Proxies to `Zend\Expressive\Helper\ServerUrlHelper::setUri()`
-     * @param UriInterface $uri
-     * @return void
      */
-    public function setUri(UriInterface $uri)
+    public function setUri(UriInterface $uri) : void
     {
         $this->helper->setUri($uri);
     }

--- a/src/ServerUrlHelper.php
+++ b/src/ServerUrlHelper.php
@@ -33,7 +33,7 @@ class ServerUrlHelper extends AbstractHelper
      *
      * Proxies to `Zend\Expressive\Helper\ServerUrlHelper::generate()`.
      */
-    public function __invoke(?string $path = null) : string
+    public function __invoke(string $path = null) : string
     {
         return $this->helper->generate($path);
     }

--- a/src/UrlHelper.php
+++ b/src/UrlHelper.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-zendviewrenderer for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-zendviewrenderer/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Expressive\ZendView;
 
@@ -28,10 +30,6 @@ class UrlHelper extends AbstractHelper
     /**
      * Proxies to `Zend\Expressive\Helper\UrlHelper::generate()`
      *
-     * @param null|string $routeName
-     * @param array $routeParams
-     * @param array $queryParams
-     * @param null|string $fragmentIdentifier
      * @param array $options Can have the following keys:
      *     - router (array): contains options to be passed to the router
      *     - reuse_result_params (bool): indicates if the current RouteResult
@@ -39,10 +37,10 @@ class UrlHelper extends AbstractHelper
      * @return string
      */
     public function __invoke(
-        $routeName = null,
+        ?string $routeName = null,
         array $routeParams = [],
         array $queryParams = [],
-        $fragmentIdentifier = null,
+        ?string $fragmentIdentifier = null,
         array $options = []
     ) {
         return $this->helper->generate($routeName, $routeParams, $queryParams, $fragmentIdentifier, $options);

--- a/src/UrlHelper.php
+++ b/src/UrlHelper.php
@@ -37,10 +37,10 @@ class UrlHelper extends AbstractHelper
      * @return string
      */
     public function __invoke(
-        ?string $routeName = null,
+        string $routeName = null,
         array $routeParams = [],
         array $queryParams = [],
-        ?string $fragmentIdentifier = null,
+        string $fragmentIdentifier = null,
         array $options = []
     ) {
         return $this->helper->generate($routeName, $routeParams, $queryParams, $fragmentIdentifier, $options);

--- a/src/ZendViewRenderer.php
+++ b/src/ZendViewRenderer.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-zendviewrenderer for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-zendviewrenderer/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Expressive\ZendView;
 
@@ -115,11 +117,9 @@ class ZendViewRenderer implements TemplateRendererInterface
      * Layouts specified with $params take precedence over layouts passed to
      * the constructor.
      *
-     * @param string $name
      * @param array|ModelInterface|object $params
-     * @return string
      */
-    public function render($name, $params = [])
+    public function render(string $name, $params = []) : string
     {
         $viewModel = $params instanceof ModelInterface
             ? $this->mergeViewModel($name, $params)
@@ -135,12 +135,8 @@ class ZendViewRenderer implements TemplateRendererInterface
 
     /**
      * Add a path for templates.
-     *
-     * @param string $path
-     * @param string $namespace
-     * @return void
      */
-    public function addPath($path, $namespace = null)
+    public function addPath(string $path, string $namespace = null) : void
     {
         $this->resolver->addPath($path, $namespace);
     }
@@ -150,7 +146,7 @@ class ZendViewRenderer implements TemplateRendererInterface
      *
      * @return TemplatePath[]
      */
-    public function getPaths()
+    public function getPaths() : array
     {
         $paths = [];
 
@@ -188,12 +184,9 @@ class ZendViewRenderer implements TemplateRendererInterface
     /**
      * Do a recursive, depth-first rendering of a view model.
      *
-     * @param ModelInterface $model
-     * @param RendererInterface $renderer
-     * @return string
      * @throws Exception\RenderingException if it encounters a terminal child.
      */
-    private function renderModel(ModelInterface $model, RendererInterface $renderer)
+    private function renderModel(ModelInterface $model, RendererInterface $renderer) : string
     {
         foreach ($model as $child) {
             if ($child->terminate()) {
@@ -221,10 +214,8 @@ class ZendViewRenderer implements TemplateRendererInterface
 
     /**
      * Returns a PhpRenderer object
-     *
-     * @return PhpRenderer
      */
-    private function createRenderer()
+    private function createRenderer() : PhpRenderer
     {
         $renderer = new PhpRenderer();
         $renderer->setResolver($this->getDefaultResolver());
@@ -233,10 +224,8 @@ class ZendViewRenderer implements TemplateRendererInterface
 
     /**
      * Get the default resolver
-     *
-     * @return AggregateResolver
      */
-    private function getDefaultResolver()
+    private function getDefaultResolver() : AggregateResolver
     {
         $resolver = new AggregateResolver();
         $this->injectNamespacedResolver($resolver);
@@ -247,20 +236,13 @@ class ZendViewRenderer implements TemplateRendererInterface
      * Attaches a new NamespacedPathStackResolver to the AggregateResolver
      *
      * A priority of 0 is used, to ensure it is the last queried.
-     *
-     * @param AggregateResolver $aggregate
-     * @return void
      */
-    private function injectNamespacedResolver(AggregateResolver $aggregate)
+    private function injectNamespacedResolver(AggregateResolver $aggregate) : void
     {
         $aggregate->attach(new NamespacedPathStackResolver(), 0);
     }
 
-    /**
-     * @param AggregateResolver $aggregate
-     * @return bool
-     */
-    private function hasNamespacedResolver(AggregateResolver $aggregate)
+    private function hasNamespacedResolver(AggregateResolver $aggregate) : bool
     {
         foreach ($aggregate as $resolver) {
             if ($resolver instanceof NamespacedPathStackResolver) {
@@ -271,11 +253,7 @@ class ZendViewRenderer implements TemplateRendererInterface
         return false;
     }
 
-    /**
-     * @param AggregateResolver $aggregate
-     * @return null|NamespacedPathStackResolver
-     */
-    private function getNamespacedResolver(AggregateResolver $aggregate)
+    private function getNamespacedResolver(AggregateResolver $aggregate) : ?NamespacedPathStackResolver
     {
         foreach ($aggregate as $resolver) {
             if ($resolver instanceof NamespacedPathStackResolver) {
@@ -290,10 +268,8 @@ class ZendViewRenderer implements TemplateRendererInterface
      * Merge global/template parameters with provided view model.
      *
      * @param string $name Template name.
-     * @param ModelInterface $model
-     * @return ModelInterface
      */
-    private function mergeViewModel($name, ModelInterface $model)
+    private function mergeViewModel(string $name, ModelInterface $model) : ModelInterface
     {
         $params = $this->mergeParams(
             $name,
@@ -321,11 +297,8 @@ class ZendViewRenderer implements TemplateRendererInterface
      * Returns the provided $viewModel unchanged if no layout is discovered;
      * otherwise, a view model representing the layout, with the provided
      * view model as a child, is returned.
-     *
-     * @param ModelInterface $viewModel
-     * @return ModelInterface
      */
-    private function prepareLayout(ModelInterface $viewModel)
+    private function prepareLayout(ModelInterface $viewModel) : ModelInterface
     {
         $providedLayout = $viewModel->getVariable('layout', null);
         if (is_string($providedLayout) && ! empty($providedLayout)) {

--- a/src/ZendViewRendererFactory.php
+++ b/src/ZendViewRendererFactory.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-zendviewrenderer for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-zendviewrenderer/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Expressive\ZendView;
 
@@ -46,11 +48,7 @@ use Zend\View\Resolver;
  */
 class ZendViewRendererFactory
 {
-    /**
-     * @param ContainerInterface $container
-     * @return ZendViewRenderer
-     */
-    public function __invoke(ContainerInterface $container)
+    public function __invoke(ContainerInterface $container) : ZendViewRenderer
     {
         $config   = $container->has('config') ? $container->get('config') : [];
         $config   = isset($config['templates']) ? $config['templates'] : [];
@@ -94,12 +92,9 @@ class ZendViewRendererFactory
      *
      * In each case, injects with the custom url/serverurl implementations.
      *
-     * @param PhpRenderer $renderer
-     * @param ContainerInterface $container
-     * @return void
      * @throws Exception\MissingHelperException
      */
-    private function injectHelpers(PhpRenderer $renderer, ContainerInterface $container)
+    private function injectHelpers(PhpRenderer $renderer, ContainerInterface $container) : void
     {
         $helpers = $container->has(HelperPluginManager::class)
             ? $container->get(HelperPluginManager::class)

--- a/test/HelperPluginManagerFactoryTest.php
+++ b/test/HelperPluginManagerFactoryTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-zendviewrenderer for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-zendviewrenderer/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\ZendView;
 

--- a/test/ServerUrlHelperTest.php
+++ b/test/ServerUrlHelperTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-zendviewrenderer for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-zendviewrenderer/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\ZendView;
 

--- a/test/TestAsset/TestHelper.php
+++ b/test/TestAsset/TestHelper.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-zendviewrenderer for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-zendviewrenderer/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\ZendView\TestAsset;
 

--- a/test/UrlHelperTest.php
+++ b/test/UrlHelperTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-zendviewrenderer for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-zendviewrenderer/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\ZendView;
 

--- a/test/ZendViewRendererFactoryTest.php
+++ b/test/ZendViewRendererFactoryTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-zendviewrenderer for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-zendviewrenderer/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\ZendView;
 
@@ -194,7 +196,7 @@ class ZendViewRendererFactoryTest extends TestCase
 
         $dirSlash = DIRECTORY_SEPARATOR;
         // @codingStandardsIgnoreStart
-        $this->assertPathNamespaceContains(__DIR__ . '/TestAsset/bar' . $dirSlash, 'foo', $paths, var_export($paths, 1));
+        $this->assertPathNamespaceContains(__DIR__ . '/TestAsset/bar' . $dirSlash, 'foo', $paths, var_export($paths, true));
         $this->assertPathNamespaceContains(__DIR__ . '/TestAsset/baz' . $dirSlash, 'bar', $paths);
         $this->assertPathNamespaceContains(__DIR__ . '/TestAsset/bat' . $dirSlash, 'bar', $paths);
         $this->assertPathNamespaceContains(__DIR__ . '/TestAsset/one' . $dirSlash, null, $paths);

--- a/test/ZendViewRendererTest.php
+++ b/test/ZendViewRendererTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-zendviewrenderer for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-zendviewrenderer/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\ZendView;
 
@@ -50,7 +52,8 @@ class ZendViewRendererTest extends TestCase
 
     public function assertTemplatePathNamespace($namespace, TemplatePath $templatePath, $message = null)
     {
-        $message = $message ?: sprintf('Failed to assert TemplatePath namespace matched %s', var_export($namespace, 1));
+        $message = $message
+            ?: sprintf('Failed to assert TemplatePath namespace matched %s', var_export($namespace, true));
         $this->assertEquals($namespace, $templatePath->getNamespace(), $message);
     }
 


### PR DESCRIPTION
This patch accomplishes the following:

- Updates dependencies
  - Drops support for PHP versions prior to 7.1.
  - Updates to zend-expressive-template v2 series.
  - Updates to zend-expressive-router v3 series.
  - Updates to zend-expressive-helpers v5 series.
  - Updates to PHPUnit 6.5 series.
- Updates to use PHP 7.1 features:
  - Adds strict_types declarations to all class files
  - Updates to use scalar and return type hints, including nullable and void types, wherever possible. In some cases, where extending classes from components that have not updated to PHP 7.1 syntax yet, typehints were omitted for compatibility.
  - Ensures `ZendViewRenderer` implements v2 signature of zend-expressive-template `TemplateRendererInterface`.