### PR TITLE
Allow default parameters to be rendered in layout

### DIFF
--- a/src/ZendViewRenderer.php
+++ b/src/ZendViewRenderer.php
@@ -342,7 +342,7 @@ class ZendViewRenderer implements TemplateRendererInterface
         if ($layout) {
             $layout->addChild($viewModel);
             $viewModel = $layout;
-            $viewModel->setVariables($this->mergeParams($layout->getTemplate(), []));
+            $viewModel->setVariables($this->mergeParams($layout->getTemplate(), (array) $layout->getVariables()));
         }
 
         return $viewModel;

--- a/src/ZendViewRenderer.php
+++ b/src/ZendViewRenderer.php
@@ -342,7 +342,7 @@ class ZendViewRenderer implements TemplateRendererInterface
         if ($layout) {
             $layout->addChild($viewModel);
             $viewModel = $layout;
-            $viewModel->setVariables($this->mergeParams(self::TEMPLATE_ALL, []));
+            $viewModel->setVariables($this->mergeParams($layout->getTemplate(), []));
         }
 
         return $viewModel;

--- a/test/ZendViewRendererTest.php
+++ b/test/ZendViewRendererTest.php
@@ -268,7 +268,7 @@ class ZendViewRendererTest extends TestCase
         $this->assertContains($expected, $result, sprintf('Received %s', $result));
     }
 
-    public function testTemplateDefaultParameterIsAvailableInProvidedLayout()
+    public function testVariableInProvidedLayoutViewModelOverridesTemplateDefaultParameter()
     {
         $renderer = new ZendViewRenderer(null);
         $renderer->addPath(__DIR__ . '/TestAsset');
@@ -294,7 +294,7 @@ class ZendViewRendererTest extends TestCase
         $this->assertContains($expected, $result, sprintf('Received %s', $result));
     }
 
-    public function testTemplateDefaultParameterWhenNotProvidedInLayoutViewModel()
+    public function testTemplateDefaultParameterIsAvailableInLayoutProvidedWithViewModel()
     {
         $renderer = new ZendViewRenderer(null);
         $renderer->addPath(__DIR__ . '/TestAsset');

--- a/test/ZendViewRendererTest.php
+++ b/test/ZendViewRendererTest.php
@@ -268,6 +268,32 @@ class ZendViewRendererTest extends TestCase
         $this->assertContains($expected, $result, sprintf('Received %s', $result));
     }
 
+    public function testTemplateDefaultParameterIsAvailableInProvidedLayout()
+    {
+        $renderer = new ZendViewRenderer(null);
+        $renderer->addPath(__DIR__ . '/TestAsset');
+        $titleToBeOverriden = uniqid('ZendViewTitleToBeOverriden', true);
+        $title = uniqid('ZendViewTitle', true);
+        $name = uniqid('ZendViewName', true);
+        $renderer->addDefaultParam('zendview-layout-variable', 'title', $titleToBeOverriden);
+
+        $layout = new ViewModel(['title' => $title]);
+        $layout->setTemplate('zendview-layout-variable');
+        $result = $renderer->render('zendview', ['name' => $name, 'layout' => $layout]);
+        $this->assertContains($title, $result);
+        $this->assertContains($name, $result);
+
+        $content = file_get_contents(__DIR__ . '/TestAsset/zendview.phtml');
+        $content = str_replace('<?php echo $name ?>', $name, $content);
+        $layout = file_get_contents(__DIR__ . '/TestAsset/zendview-layout-variable.phtml');
+        $layout = str_replace('<?= $this->title ?>', $title, $layout);
+        $layout = str_replace('<?= $this->content ?>' . PHP_EOL, $content, $layout);
+        $this->assertContains($layout, $result);
+
+        $expected = sprintf('<title>Layout Page: %s</title>', $title);
+        $this->assertContains($expected, $result, sprintf('Received %s', $result));
+    }
+
     /**
      * @group layout
      */

--- a/test/ZendViewRendererTest.php
+++ b/test/ZendViewRendererTest.php
@@ -246,7 +246,7 @@ class ZendViewRendererTest extends TestCase
         $this->assertContains($expected, $result, sprintf('Received %s', $result));
     }
 
-    public function testTemplateDefaultParameterIsAvailableInLayout()
+    public function testLayoutTemplateDefaultParameterIsAvailableInLayout()
     {
         $renderer = new ZendViewRenderer(null, 'zendview-layout-variable');
         $renderer->addPath(__DIR__ . '/TestAsset');
@@ -298,25 +298,24 @@ class ZendViewRendererTest extends TestCase
     {
         $renderer = new ZendViewRenderer(null);
         $renderer->addPath(__DIR__ . '/TestAsset');
-        $titleNotToBeOverriden = uniqid('ZendViewTitleNotToBeOverriden', true);
         $title = uniqid('ZendViewTitle', true);
         $name = uniqid('ZendViewName', true);
-        $renderer->addDefaultParam('zendview-layout-variable', 'title', $titleNotToBeOverriden);
+        $renderer->addDefaultParam('zendview-layout-variable', 'title', $title);
 
         $layout = new ViewModel();
         $layout->setTemplate('zendview-layout-variable');
         $result = $renderer->render('zendview', ['name' => $name, 'layout' => $layout]);
-        $this->assertContains($titleNotToBeOverriden, $result);
+        $this->assertContains($title, $result);
         $this->assertContains($name, $result);
 
         $content = file_get_contents(__DIR__ . '/TestAsset/zendview.phtml');
         $content = str_replace('<?php echo $name ?>', $name, $content);
         $layout = file_get_contents(__DIR__ . '/TestAsset/zendview-layout-variable.phtml');
-        $layout = str_replace('<?= $this->title ?>', $titleNotToBeOverriden, $layout);
+        $layout = str_replace('<?= $this->title ?>', $title, $layout);
         $layout = str_replace('<?= $this->content ?>' . PHP_EOL, $content, $layout);
         $this->assertContains($layout, $result);
 
-        $expected = sprintf('<title>Layout Page: %s</title>', $titleNotToBeOverriden);
+        $expected = sprintf('<title>Layout Page: %s</title>', $title);
         $this->assertContains($expected, $result, sprintf('Received %s', $result));
     }
 

--- a/test/ZendViewRendererTest.php
+++ b/test/ZendViewRendererTest.php
@@ -294,6 +294,32 @@ class ZendViewRendererTest extends TestCase
         $this->assertContains($expected, $result, sprintf('Received %s', $result));
     }
 
+    public function testTemplateDefaultParameterWhenNotProvidedInLayoutViewModel()
+    {
+        $renderer = new ZendViewRenderer(null);
+        $renderer->addPath(__DIR__ . '/TestAsset');
+        $titleNotToBeOverriden = uniqid('ZendViewTitleNotToBeOverriden', true);
+        $title = uniqid('ZendViewTitle', true);
+        $name = uniqid('ZendViewName', true);
+        $renderer->addDefaultParam('zendview-layout-variable', 'title', $titleNotToBeOverriden);
+
+        $layout = new ViewModel();
+        $layout->setTemplate('zendview-layout-variable');
+        $result = $renderer->render('zendview', ['name' => $name, 'layout' => $layout]);
+        $this->assertContains($titleNotToBeOverriden, $result);
+        $this->assertContains($name, $result);
+
+        $content = file_get_contents(__DIR__ . '/TestAsset/zendview.phtml');
+        $content = str_replace('<?php echo $name ?>', $name, $content);
+        $layout = file_get_contents(__DIR__ . '/TestAsset/zendview-layout-variable.phtml');
+        $layout = str_replace('<?= $this->title ?>', $titleNotToBeOverriden, $layout);
+        $layout = str_replace('<?= $this->content ?>' . PHP_EOL, $content, $layout);
+        $this->assertContains($layout, $result);
+
+        $expected = sprintf('<title>Layout Page: %s</title>', $titleNotToBeOverriden);
+        $this->assertContains($expected, $result, sprintf('Received %s', $result));
+    }
+
     /**
      * @group layout
      */

--- a/test/ZendViewRendererTest.php
+++ b/test/ZendViewRendererTest.php
@@ -246,6 +246,28 @@ class ZendViewRendererTest extends TestCase
         $this->assertContains($expected, $result, sprintf('Received %s', $result));
     }
 
+    public function testTemplateDefaultParameterIsAvailableInLayout()
+    {
+        $renderer = new ZendViewRenderer(null, 'zendview-layout-variable');
+        $renderer->addPath(__DIR__ . '/TestAsset');
+        $title = uniqid('ZendViewTitle', true);
+        $name = uniqid('ZendViewName', true);
+        $renderer->addDefaultParam('zendview-layout-variable', 'title', $title);
+        $result = $renderer->render('zendview', ['name' => $name]);
+        $this->assertContains($title, $result);
+        $this->assertContains($name, $result);
+
+        $content = file_get_contents(__DIR__ . '/TestAsset/zendview.phtml');
+        $content = str_replace('<?php echo $name ?>', $name, $content);
+        $layout = file_get_contents(__DIR__ . '/TestAsset/zendview-layout-variable.phtml');
+        $layout = str_replace('<?= $this->title ?>', $title, $layout);
+        $layout = str_replace('<?= $this->content ?>' . PHP_EOL, $content, $layout);
+        $this->assertContains($layout, $result);
+
+        $expected = sprintf('<title>Layout Page: %s</title>', $title);
+        $this->assertContains($expected, $result, sprintf('Received %s', $result));
+    }
+
     /**
      * @group layout
      */


### PR DESCRIPTION
- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
When trying to add default parameters to a specific layout, it is expected that the value parameters will be rendered and shown in layout.  They are not.

  - [x] Detail the original, incorrect behavior.
using `addDefaultParam` on `$renderer` is expected to "provide a default parameter to use when a template is rendered".  Currently, the method does not provide a default parameter when it is applied to a specific layout.

  - [x] Detail the new, expected behavior.
`addDefaultParam` provides a default parameter to use when a template is rendered, including when specifying a specific custom template.

- [x] Is this related to quality assurance?
I could say that it relates to quality assurance, since this change is aimed at enforcing expected behavior.
