### PR TITLE
Add missing default layout

### DIFF
--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -38,6 +38,7 @@ class ConfigProvider
     public function getTemplates() : array
     {
         return [
+            'layout' => 'layout::default',
             'paths' => [],
         ];
     }


### PR DESCRIPTION
When creating a project with the expressive skeleton, the layout is not loaded. This adds the default layout so it will be loaded.