### PR TITLE
Default params now passed to child models. Fixes #57.

### DIFF
--- a/src/ZendViewRenderer.php
+++ b/src/ZendViewRenderer.php
@@ -205,6 +205,7 @@ class ZendViewRenderer implements TemplateRendererInterface
                 continue;
             }
 
+            $child  = $this->mergeViewModel($child->getTemplate(), $child);
             $result = $this->renderModel($child, $renderer);
 
             if ($child->isAppend()) {

--- a/test/ZendViewRendererTest.php
+++ b/test/ZendViewRendererTest.php
@@ -581,4 +581,29 @@ class ZendViewRendererTest extends TestCase
 
         $this->assertEquals($content, $result);
     }
+
+    public function testRenderChildWithDefaultParameter()
+    {
+        $name2 = 'Foo';
+
+        $renderer = new ZendViewRenderer();
+        $renderer->addPath(__DIR__ . '/TestAsset');
+        $renderer->addDefaultParam('zendview-2', 'name', $name2);
+
+        $viewModelChild = new ViewModel();
+        $viewModelChild->setTemplate('zendview-2');
+
+        $viewModelParent = new ViewModel();
+        $viewModelParent->addChild($viewModelChild, 'name');
+
+        $result = $renderer->render('zendview', $viewModelParent);
+
+        $contentChild = file_get_contents(__DIR__ . '/TestAsset/zendview-2.phtml');
+        $contentChild = str_replace('<?php echo $name ?>', $name2, $contentChild);
+
+        $content = file_get_contents(__DIR__ . '/TestAsset/zendview.phtml');
+        $content = str_replace('<?php echo $name ?>', $contentChild, $content);
+
+        static::assertEquals($content, $result);
+    }
 }


### PR DESCRIPTION
Pass default parameters to child view models:

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
Detailed in #57 
  - [x] Detail the original, incorrect behavior.
Detailed in #57 
  - [x] Detail the new, expected behavior. 
Default parameters for the child template and all templates are passed to child view model
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
See `\ZendTest\Expressive\ZendView\ZendViewRendererTest::testRenderChildWithDefaultParameter`
  - [ ] Add a `CHANGELOG.md` entry for the fix.
(should I?)

- [x] Is this related to quality assurance?
I think not.

- [x] Is this related to documentation?
No.