### PR TITLE
Change ZendViewRenderer to DI only; remove fallback dependency setup

### DIFF
--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -11,6 +11,7 @@ namespace Zend\Expressive\ZendView;
 
 use Zend\Expressive\Template\TemplateRendererInterface;
 use Zend\View\HelperPluginManager;
+use Zend\View\Renderer\PhpRenderer;
 
 class ConfigProvider
 {
@@ -30,6 +31,8 @@ class ConfigProvider
             ],
             'factories' => [
                 HelperPluginManager::class => HelperPluginManagerFactory::class,
+                NamespacedPathStackResolver::class => NamespacedPathStackResolverFactory::class,
+                PhpRenderer::class => PhpRendererFactory::class,
                 ZendViewRenderer::class => ZendViewRendererFactory::class,
             ],
         ];

--- a/src/HelperPluginManagerFactory.php
+++ b/src/HelperPluginManagerFactory.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-zendviewrenderer for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
+ * @copyright Copyright (c) 2015-2019 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-zendviewrenderer/blob/master/LICENSE.md New BSD License
  */
 
@@ -10,10 +10,12 @@ declare(strict_types=1);
 namespace Zend\Expressive\ZendView;
 
 use Psr\Container\ContainerInterface;
+use Zend\Expressive\Helper\ServerUrlHelper as BaseServerUrlHelper;
+use Zend\Expressive\Helper\UrlHelper as BaseUrlHelper;
 use Zend\ServiceManager\Config;
 use Zend\View\HelperPluginManager;
 
-class HelperPluginManagerFactory
+final class HelperPluginManagerFactory
 {
     public function __invoke(ContainerInterface $container) : HelperPluginManager
     {
@@ -26,6 +28,45 @@ class HelperPluginManagerFactory
             (new Config($config))->configureServiceManager($manager);
         }
 
+        $this->injectHelpers($manager, $container);
         return $manager;
+    }
+
+    /**
+     * Inject helpers into the HelperPhpRenderer instance.
+     *
+     * If a HelperPluginManager instance is present in the container, uses that;
+     * otherwise, instantiates one.
+     *
+     * In each case, injects with the custom url/serverurl implementations.
+     *
+     * @throws Exception\MissingHelperException
+     */
+    private function injectHelpers(HelperPluginManager $helpers, ContainerInterface $container) : void
+    {
+        $helpers->setAlias('url', BaseUrlHelper::class);
+        $helpers->setAlias('Url', BaseUrlHelper::class);
+        $helpers->setFactory(BaseUrlHelper::class, static function () use ($container) {
+            if (! $container->has(BaseUrlHelper::class)) {
+                throw new Exception\MissingHelperException(sprintf(
+                    'An instance of %s is required in order to create the "url" view helper; not found',
+                    BaseUrlHelper::class
+                ));
+            }
+            return new UrlHelper($container->get(BaseUrlHelper::class));
+        });
+
+        $helpers->setAlias('serverurl', BaseServerUrlHelper::class);
+        $helpers->setAlias('serverUrl', BaseServerUrlHelper::class);
+        $helpers->setAlias('ServerUrl', BaseServerUrlHelper::class);
+        $helpers->setFactory(BaseServerUrlHelper::class, static function () use ($container) {
+            if (! $container->has(BaseServerUrlHelper::class)) {
+                throw new Exception\MissingHelperException(sprintf(
+                    'An instance of %s is required in order to create the "url" view helper; not found',
+                    BaseServerUrlHelper::class
+                ));
+            }
+            return new ServerUrlHelper($container->get(BaseServerUrlHelper::class));
+        });
     }
 }

--- a/src/NamespacedPathStackResolverFactory.php
+++ b/src/NamespacedPathStackResolverFactory.php
@@ -11,7 +11,7 @@ namespace Zend\Expressive\ZendView;
 
 use Psr\Container\ContainerInterface;
 
-class NamespacedPathStackResolverFactory
+final class NamespacedPathStackResolverFactory
 {
     public function __invoke(ContainerInterface $container) : NamespacedPathStackResolver
     {
@@ -19,8 +19,8 @@ class NamespacedPathStackResolverFactory
         $config   = $config['templates'] ?? [];
 
         $resolver = new NamespacedPathStackResolver();
-        if (! empty($config['default_suffix'])) {
-            $resolver->setDefaultSuffix($config['default_suffix']);
+        if (! empty($config['extension'])) {
+            $resolver->setDefaultSuffix($config['extension']);
         }
 
         return $resolver;

--- a/src/PhpRendererFactory.php
+++ b/src/PhpRendererFactory.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-zendviewrenderer for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-zendviewrenderer/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\ZendView;
+
+use Psr\Container\ContainerInterface;
+use Zend\View\HelperPluginManager;
+use Zend\View\Renderer\PhpRenderer;
+use Zend\View\Resolver\AggregateResolver;
+use Zend\View\Resolver\TemplateMapResolver;
+
+final class PhpRendererFactory
+{
+    public function __invoke(ContainerInterface $container) : PhpRenderer
+    {
+        $config   = $container->has('config') ? $container->get('config') : [];
+
+        $resolver = new AggregateResolver();
+        $resolver->attach(
+            new TemplateMapResolver($config['templates']['map'] ?? []),
+            100
+        );
+
+        $nsPathResolver = $container->get(NamespacedPathStackResolver::class);
+        $resolver->attach(
+            $nsPathResolver,
+            0
+        );
+
+        $renderer = new PhpRenderer();
+        $renderer->setResolver($resolver);
+
+        $helpers = $container->get(HelperPluginManager::class);
+        $renderer->setHelperPluginManager($helpers);
+
+        return $renderer;
+    }
+}

--- a/src/ZendViewRenderer.php
+++ b/src/ZendViewRenderer.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-zendviewrenderer for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
+ * @copyright Copyright (c) 2015-2019 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-zendviewrenderer/blob/master/LICENSE.md New BSD License
  */
 
@@ -44,7 +44,7 @@ class ZendViewRenderer implements TemplateRendererInterface
     use DefaultParamsTrait;
 
     /**
-     * @var ViewModel
+     * @var null|ModelInterface
      */
     private $layout;
 
@@ -207,6 +207,7 @@ class ZendViewRenderer implements TemplateRendererInterface
             $root = $model;
         }
 
+        /** @var ModelInterface $child */
         foreach ($model as $child) {
             if ($child->terminate()) {
                 throw new Exception\RenderingException('Cannot render; encountered a child marked terminal');
@@ -219,7 +220,8 @@ class ZendViewRenderer implements TemplateRendererInterface
 
             $child  = $this->mergeViewModel($child->getTemplate(), $child);
 
-            if ($child !== $root) {
+            if ($renderer instanceof PhpRenderer && $child !== $root) {
+                /** @var Helper\ViewModel $viewModelHelper */
                 $viewModelHelper = $renderer->plugin(Helper\ViewModel::class);
                 $viewModelHelper->setRoot($root);
             }

--- a/src/ZendViewRenderer.php
+++ b/src/ZendViewRenderer.php
@@ -19,7 +19,6 @@ use Zend\View\Model\ModelInterface;
 use Zend\View\Model\ViewModel;
 use Zend\View\Renderer\PhpRenderer;
 use Zend\View\Renderer\RendererInterface;
-use Zend\View\Resolver\AggregateResolver;
 
 use function get_class;
 use function gettype;
@@ -32,11 +31,6 @@ use function sprintf;
  * Template implementation bridging zendframework/zend-view.
  *
  * This implementation provides additional capabilities.
- *
- * First, it always ensures the resolver is an AggregateResolver, pushing any
- * non-Aggregate into a new AggregateResolver instance. Additionally, it always
- * registers a NamespacedPathStackResolver at priority 0 (lower than
- * default) in the Aggregate to ensure we can add and resolve namespaced paths.
  */
 class ZendViewRenderer implements TemplateRendererInterface
 {
@@ -64,35 +58,27 @@ class ZendViewRenderer implements TemplateRendererInterface
      * Allows specifying the renderer to use (any zend-view renderer is
      * allowed), and optionally also the layout.
      *
+     * Renderer is expected to be already configured with NamespacedPathStackResolver,
+     * typically in AggregateResolver at priority 0 (lower than default), to
+     * ensure we can add and resolve namespaced paths.
+     *
      * The layout may be:
      *
      * - a string layout name
      * - a ModelInterface instance representing the layout
      *
-     * If no renderer is provided, a default PhpRenderer instance is created;
-     * omitting the layout indicates no layout should be used by default when
+     * Omitting the layout indicates no layout should be used by default when
      * rendering.
      *
-     * @param null|RendererInterface $renderer
+     * @param RendererInterface $renderer
+     * @param NamespacedPathStackResolver $resolver
      * @param null|string|ModelInterface $layout
-     * @param null|string $defaultSuffix The default template file suffix, if any
      * @throws Exception\InvalidArgumentException for invalid $layout types
      */
-    public function __construct(RendererInterface $renderer = null, $layout = null, string $defaultSuffix = null)
+    public function __construct(RendererInterface $renderer, NamespacedPathStackResolver $resolver, $layout = null)
     {
-        if (null === $renderer) {
-            $renderer = $this->createRenderer();
-            $resolver = $renderer->resolver();
-        } else {
-            $resolver = $renderer->resolver();
-            if (! $resolver instanceof AggregateResolver) {
-                $aggregate = $this->getDefaultResolver();
-                $aggregate->attach($resolver);
-                $resolver = $aggregate;
-            } elseif (! $this->hasNamespacedResolver($resolver)) {
-                $this->injectNamespacedResolver($resolver);
-            }
-        }
+        $this->renderer = $renderer;
+        $this->resolver = $resolver;
 
         if ($layout && is_string($layout)) {
             $model = new ViewModel();
@@ -108,11 +94,6 @@ class ZendViewRenderer implements TemplateRendererInterface
             ));
         }
 
-        $this->renderer = $renderer;
-        $this->resolver = $this->getNamespacedResolver($resolver);
-        if (null !== $defaultSuffix) {
-            $this->resolver->setDefaultSuffix($defaultSuffix);
-        }
         $this->layout   = $layout;
     }
 
@@ -238,58 +219,6 @@ class ZendViewRenderer implements TemplateRendererInterface
         }
 
         return $renderer->render($model);
-    }
-
-    /**
-     * Returns a PhpRenderer object
-     */
-    private function createRenderer() : PhpRenderer
-    {
-        $renderer = new PhpRenderer();
-        $renderer->setResolver($this->getDefaultResolver());
-        return $renderer;
-    }
-
-    /**
-     * Get the default resolver
-     */
-    private function getDefaultResolver() : AggregateResolver
-    {
-        $resolver = new AggregateResolver();
-        $this->injectNamespacedResolver($resolver);
-        return $resolver;
-    }
-
-    /**
-     * Attaches a new NamespacedPathStackResolver to the AggregateResolver
-     *
-     * A priority of 0 is used, to ensure it is the last queried.
-     */
-    private function injectNamespacedResolver(AggregateResolver $aggregate) : void
-    {
-        $aggregate->attach(new NamespacedPathStackResolver(), 0);
-    }
-
-    private function hasNamespacedResolver(AggregateResolver $aggregate) : bool
-    {
-        foreach ($aggregate as $resolver) {
-            if ($resolver instanceof NamespacedPathStackResolver) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private function getNamespacedResolver(AggregateResolver $aggregate) : ?NamespacedPathStackResolver
-    {
-        foreach ($aggregate as $resolver) {
-            if ($resolver instanceof NamespacedPathStackResolver) {
-                return $resolver;
-            }
-        }
-
-        return null;
     }
 
     /**

--- a/src/ZendViewRendererFactory.php
+++ b/src/ZendViewRendererFactory.php
@@ -10,24 +10,13 @@ declare(strict_types=1);
 namespace Zend\Expressive\ZendView;
 
 use Psr\Container\ContainerInterface;
-use Zend\Expressive\Helper\ServerUrlHelper as BaseServerUrlHelper;
-use Zend\Expressive\Helper\UrlHelper as BaseUrlHelper;
-use Zend\View\HelperPluginManager;
 use Zend\View\Renderer\PhpRenderer;
-use Zend\View\Resolver;
 
 use function is_array;
 use function is_numeric;
-use function sprintf;
 
 /**
  * Create and return a ZendView template instance.
- *
- * Requires the Zend\Expressive\Router\RouterInterface service (for creating
- * the UrlHelper instance).
- *
- * Optionally requires the Zend\View\HelperPluginManager service; if present,
- * will use the service to inject the PhpRenderer instance.
  *
  * Optionally uses the service 'config', which should return an array. This
  * factory consumes the following structure:
@@ -47,43 +36,16 @@ use function sprintf;
  *     ],
  * ]
  * </code>
- *
- * Injects the HelperPluginManager used by the PhpRenderer with zend-expressive
- * overrides of the url and serverurl helpers.
  */
-class ZendViewRendererFactory
+final class ZendViewRendererFactory
 {
     public function __invoke(ContainerInterface $container) : ZendViewRenderer
     {
         $config   = $container->has('config') ? $container->get('config') : [];
         $config   = $config['templates'] ?? [];
 
-
-        // Configuration
-        $resolver = new Resolver\AggregateResolver();
-        $resolver->attach(
-            new Resolver\TemplateMapResolver($config['map'] ?? []),
-            100
-        );
-
-        $nsPathResolver = new NamespacedPathStackResolver();
-        // Set default suffix
-        if (isset($config['extension'])) {
-            $nsPathResolver->setDefaultSuffix($config['extension']);
-        }
-        $resolver->attach(
-            $nsPathResolver,
-            0
-        );
-
-        // Create or retrieve the renderer from the container
-        $renderer = $container->has(PhpRenderer::class)
-            ? $container->get(PhpRenderer::class)
-            : new PhpRenderer();
-        $renderer->setResolver($resolver);
-
-        // Inject helpers
-        $this->injectHelpers($renderer, $container);
+        $renderer = $container->get(PhpRenderer::class);
+        $nsPathResolver = $container->get(NamespacedPathStackResolver::class);
 
         // Inject renderer
         $view = new ZendViewRenderer($renderer, $nsPathResolver, $config['layout'] ?? null);
@@ -98,57 +60,5 @@ class ZendViewRendererFactory
         }
 
         return $view;
-    }
-
-    /**
-     * Inject helpers into the PhpRenderer instance.
-     *
-     * If a HelperPluginManager instance is present in the container, uses that;
-     * otherwise, instantiates one.
-     *
-     * In each case, injects with the custom url/serverurl implementations.
-     *
-     * @throws Exception\InvalidContainerException if the $container argument
-     *     does not implement InteropContainerInterface.
-     * @throws Exception\MissingHelperException
-     */
-    private function injectHelpers(PhpRenderer $renderer, ContainerInterface $container) : void
-    {
-        $helpers = $this->retrieveHelperManager($container);
-        $helpers->setAlias('url', BaseUrlHelper::class);
-        $helpers->setAlias('Url', BaseUrlHelper::class);
-        $helpers->setFactory(BaseUrlHelper::class, function () use ($container) {
-            if (! $container->has(BaseUrlHelper::class)) {
-                throw new Exception\MissingHelperException(sprintf(
-                    'An instance of %s is required in order to create the "url" view helper; not found',
-                    BaseUrlHelper::class
-                ));
-            }
-            return new UrlHelper($container->get(BaseUrlHelper::class));
-        });
-
-        $helpers->setAlias('serverurl', BaseServerUrlHelper::class);
-        $helpers->setAlias('serverUrl', BaseServerUrlHelper::class);
-        $helpers->setAlias('ServerUrl', BaseServerUrlHelper::class);
-        $helpers->setFactory(BaseServerUrlHelper::class, function () use ($container) {
-            if (! $container->has(BaseServerUrlHelper::class)) {
-                throw new Exception\MissingHelperException(sprintf(
-                    'An instance of %s is required in order to create the "url" view helper; not found',
-                    BaseServerUrlHelper::class
-                ));
-            }
-            return new ServerUrlHelper($container->get(BaseServerUrlHelper::class));
-        });
-
-        $renderer->setHelperPluginManager($helpers);
-    }
-
-    private function retrieveHelperManager(ContainerInterface $container) : HelperPluginManager
-    {
-        if ($container->has(HelperPluginManager::class)) {
-            return $container->get(HelperPluginManager::class);
-        }
-
-        return new HelperPluginManager($container);
     }
 }

--- a/src/ZendViewRendererFactory.php
+++ b/src/ZendViewRendererFactory.php
@@ -66,6 +66,16 @@ class ZendViewRendererFactory
             100
         );
 
+        $nsPathResolver = new NamespacedPathStackResolver();
+        // Set default suffix
+        if (isset($config['extension'])) {
+            $nsPathResolver->setDefaultSuffix($config['extension']);
+        }
+        $resolver->attach(
+            $nsPathResolver,
+            0
+        );
+
         // Create or retrieve the renderer from the container
         $renderer = $container->has(PhpRenderer::class)
             ? $container->get(PhpRenderer::class)
@@ -75,9 +85,8 @@ class ZendViewRendererFactory
         // Inject helpers
         $this->injectHelpers($renderer, $container);
 
-        $defaultSuffix = $config['extension'] ?? $config['default_suffix'] ?? null;
         // Inject renderer
-        $view = new ZendViewRenderer($renderer, $config['layout'] ?? null, $defaultSuffix);
+        $view = new ZendViewRenderer($renderer, $nsPathResolver, $config['layout'] ?? null);
 
         // Add template paths
         $allPaths = isset($config['paths']) && is_array($config['paths']) ? $config['paths'] : [];

--- a/test/HelperPluginManagerFactoryTest.php
+++ b/test/HelperPluginManagerFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-zendviewrenderer for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
+ * @copyright Copyright (c) 2015-2019 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-zendviewrenderer/blob/master/LICENSE.md New BSD License
  */
 
@@ -11,21 +11,24 @@ namespace ZendTest\Expressive\ZendView;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ProphecyInterface;
+use Psr\Container\ContainerInterface;
+use Zend\Expressive\Helper as ExpressiveHelper;
 use Zend\Expressive\ZendView\HelperPluginManagerFactory;
-use Zend\ServiceManager\ServiceManager;
+use Zend\Expressive\ZendView\ServerUrlHelper;
+use Zend\Expressive\ZendView\UrlHelper;
 use Zend\View\HelperPluginManager;
 use ZendTest\Expressive\ZendView\TestAsset\TestHelper;
 
 class HelperPluginManagerFactoryTest extends TestCase
 {
     /**
-     * @var ServiceManager|ProphecyInterface
+     * @var ContainerInterface|ProphecyInterface
      */
     private $container;
 
     public function setUp()
     {
-        $this->container = $this->prophesize(ServiceManager::class);
+        $this->container = $this->prophesize(ContainerInterface::class);
     }
 
     public function testCallingFactoryWithNoConfigReturnsHelperPluginManagerInstance()
@@ -65,5 +68,26 @@ class HelperPluginManagerFactoryTest extends TestCase
         $this->assertTrue($manager->has('testHelper'));
         $this->assertInstanceOf(TestHelper::class, $manager->get('testHelper'));
         return $manager;
+    }
+
+    public function testInjectsCustomHelpersIntoHelperManager()
+    {
+        $this->container->has(ExpressiveHelper\UrlHelper::class)->willReturn(true);
+        $this->container->get(ExpressiveHelper\UrlHelper::class)->willReturn(
+            $this->prophesize(ExpressiveHelper\UrlHelper::class)->reveal()
+        );
+        $this->container->has(ExpressiveHelper\ServerUrlHelper::class)->willReturn(true);
+        $this->container->get(ExpressiveHelper\ServerUrlHelper::class)->willReturn(
+            $this->prophesize(ExpressiveHelper\ServerUrlHelper::class)->reveal()
+        );
+
+        $this->container->has('config')->willReturn(false);
+        $factory = new HelperPluginManagerFactory();
+        $helpers = $factory($this->container->reveal());
+
+        $this->assertTrue($helpers->has('url'));
+        $this->assertTrue($helpers->has('serverurl'));
+        $this->assertInstanceOf(UrlHelper::class, $helpers->get('url'));
+        $this->assertInstanceOf(ServerUrlHelper::class, $helpers->get('serverurl'));
     }
 }

--- a/test/NamespacedPathStackResolverFactoryTest.php
+++ b/test/NamespacedPathStackResolverFactoryTest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-zendviewrenderer for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-zendviewrenderer/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\ZendView;
+
+use Prophecy\Prophecy\ProphecyInterface;
+use Psr\Container\ContainerInterface;
+use Zend\Expressive\ZendView\NamespacedPathStackResolver;
+use Zend\Expressive\ZendView\NamespacedPathStackResolverFactory;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Zend\Expressive\ZendView\NamespacedPathStackResolverFactory
+ */
+class NamespacedPathStackResolverFactoryTest extends TestCase
+{
+    /**
+     * @var ContainerInterface|ProphecyInterface
+     */
+    private $container;
+
+    public function setUp()
+    {
+        $this->container = $this->prophesize(ContainerInterface::class);
+    }
+
+    public function canCreateResolver()
+    {
+        $factory = new NamespacedPathStackResolverFactory();
+        $resolver = $factory($this->container->reveal());
+        $this->assertInstanceOf(NamespacedPathStackResolver::class, $resolver);
+    }
+
+    public function testConfiguresCustomDefaultSuffix()
+    {
+        $config = [
+            'templates' => [
+                'extension' => 'php',
+            ],
+        ];
+
+        $this->container->has('config')->willReturn(true);
+        $this->container->get('config')->willReturn($config);
+
+        $factory = new NamespacedPathStackResolverFactory();
+        $resolver = $factory($this->container->reveal());
+        $this->assertEquals('php', $resolver->getDefaultSuffix());
+    }
+}

--- a/test/PhpRendererFactoryTest.php
+++ b/test/PhpRendererFactoryTest.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-zendviewrenderer for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-zendviewrenderer/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\ZendView;
+
+use Prophecy\Prophecy\ObjectProphecy;
+use Prophecy\Prophecy\ProphecyInterface;
+use Psr\Container\ContainerInterface;
+use Zend\Expressive\ZendView\NamespacedPathStackResolver;
+use Zend\Expressive\ZendView\PhpRendererFactory;
+use PHPUnit\Framework\TestCase;
+use Zend\View\HelperPluginManager;
+use Zend\View\Resolver\AggregateResolver;
+use Zend\View\Resolver\TemplateMapResolver;
+
+/**
+ * @covers \Zend\Expressive\ZendView\PhpRendererFactory
+ */
+class PhpRendererFactoryTest extends TestCase
+{
+    /**
+     * @var ContainerInterface|ProphecyInterface
+     */
+    private $container;
+
+    public function setUp()
+    {
+        $this->container = $this->prophesize(ContainerInterface::class);
+        $this->container->has('config')->willReturn(false);
+    }
+
+    public function injectContainerService($name, $service)
+    {
+        $this->container->has($name)->willReturn(true);
+        $this->container->get($name)->willReturn(
+            $service instanceof ObjectProphecy ? $service->reveal() : $service
+        );
+    }
+
+    public function testWillUseHelperPluginManagerFromContainer()
+    {
+        $this->injectContainerService(
+            NamespacedPathStackResolver::class,
+            new NamespacedPathStackResolver()
+        );
+        $helpers = new HelperPluginManager($this->container->reveal());
+        $this->injectContainerService(HelperPluginManager::class, $helpers);
+        $factory = new PhpRendererFactory();
+        $renderer = $factory($this->container->reveal());
+        $this->assertSame($helpers, $renderer->getHelperPluginManager());
+    }
+
+    public function testConfiguresAggregateResolver()
+    {
+        $this->injectContainerService(
+            HelperPluginManager::class,
+            new HelperPluginManager($this->container->reveal())
+        );
+        $nsResolver = new NamespacedPathStackResolver();
+        $this->injectContainerService(NamespacedPathStackResolver::class, $nsResolver);
+        $factory = new PhpRendererFactory();
+        $renderer = $factory($this->container->reveal());
+        $aggregate = $renderer->resolver();
+        $this->assertInstanceOf(AggregateResolver::class, $aggregate);
+        $this->assertContains($nsResolver, $aggregate, 'Expected NamespacedPathStackResolver not found!');
+        $resolver = null;
+        foreach ($aggregate as $resolver) {
+            if ($resolver instanceof TemplateMapResolver) {
+                break;
+            }
+        }
+        $this->assertInstanceOf(TemplateMapResolver::class, $resolver, 'Expected TemplateMapResolver not found!');
+    }
+
+    public function testConfiguresTemplateMap()
+    {
+        $config = [
+            'templates' => [
+                'map' => [
+                    'foo' => 'bar',
+                    'bar' => 'baz',
+                ],
+            ],
+        ];
+        $this->injectContainerService('config', $config);
+        $this->injectContainerService(
+            HelperPluginManager::class,
+            new HelperPluginManager($this->container->reveal())
+        );
+        $this->injectContainerService(
+            NamespacedPathStackResolver::class,
+            new NamespacedPathStackResolver()
+        );
+        $factory = new PhpRendererFactory();
+        $renderer = $factory($this->container->reveal());
+        $aggregate = $renderer->resolver();
+        $this->assertInstanceOf(AggregateResolver::class, $aggregate);
+        $resolver = false;
+        foreach ($aggregate as $resolver) {
+            if ($resolver instanceof TemplateMapResolver) {
+                break;
+            }
+        }
+        $this->assertInstanceOf(TemplateMapResolver::class, $resolver, 'Expected TemplateMapResolver not found!');
+        $this->assertTrue($resolver->has('foo'));
+        $this->assertEquals('bar', $resolver->get('foo'));
+        $this->assertTrue($resolver->has('bar'));
+        $this->assertEquals('baz', $resolver->get('bar'));
+    }
+
+    public function testWillUseHelperManagerFromContainer()
+    {
+        $helpers = new HelperPluginManager($this->container->reveal());
+        $this->injectContainerService(HelperPluginManager::class, $helpers);
+        $this->injectContainerService(
+            NamespacedPathStackResolver::class,
+            new NamespacedPathStackResolver()
+        );
+        $factory = new PhpRendererFactory();
+        $renderer = $factory($this->container->reveal());
+
+        $this->assertSame($helpers, $renderer->getHelperPluginManager());
+        return $helpers;
+    }
+}

--- a/test/ZendViewRendererFactoryTest.php
+++ b/test/ZendViewRendererFactoryTest.php
@@ -278,34 +278,6 @@ class ZendViewRendererFactoryTest extends TestCase
         $this->assertEquals('php', $resolver->getDefaultSuffix());
     }
 
-    public function testConfiguresDeprecatedDefaultSuffix()
-    {
-        $config = [
-            'templates' => [
-                'default_suffix' => 'php',
-            ],
-        ];
-
-        $this->container->has('config')->willReturn(true);
-        $this->container->get('config')->willReturn($config);
-        $this->container->has(HelperPluginManager::class)->willReturn(false);
-        $this->container->has(PhpRenderer::class)->willReturn(false);
-
-        $factory = new ZendViewRendererFactory();
-        $view = $factory($this->container->reveal());
-
-        $r = new ReflectionProperty($view, 'resolver');
-        $r->setAccessible(true);
-        $resolver  = $r->getValue($view);
-
-        $this->assertInstanceOf(
-            NamespacedPathStackResolver::class,
-            $resolver,
-            'Expected NamespacedPathStackResolver not found!'
-        );
-        $this->assertEquals('php', $resolver->getDefaultSuffix());
-    }
-
     public function testInjectsCustomHelpersIntoHelperManager()
     {
         $this->container->has('config')->willReturn(false);


### PR DESCRIPTION
Provide a narrative description of what you are trying to accomplish:

This PR removes fallback PhpRenderer setup from ZendViewRenderer and moves NamespacedPathStackResolver setup into factory.
ZendViewRenderer requires zend-view renderer and NamespacedPathStackResolver to be explicitly provided at creation time; It won't try to inspect or configure zend-view renderer resolvers and expects them to be configured beforehand. 
    
- [x] Are you creating a new feature?
  - [x] Why is the new feature needed? What purpose does it serve?
   This greatly simplifies template renderer and forces separation of concern to avoid the need to modify template renderer to configure its dependencies as has been done in #64 
    Extra ZendViewRenderer parameter added in #64 is dropped in this PR as that feature is moved into factory.
  - [x] How will users use the new feature?
    Users depending on `Zend\Expressive\ZendView\ConfigProvider`  to configure their container can continue to use the same provided services without change.
    Users directly instantiating `Zend\Expressive\ZendView\ZendViewRenderer` will need to update their code to provide zend-view renderer (PhpRenderer by default) and NamespacedPathStackResolver as constructor parameters; zend-view renderer is expected to be already configured with NamespacedPathStackResolver.
  - [x] Base your feature on the `develop` branch, and submit against that branch.
  - [x] Add only one feature per pull request; split multiple features over multiple pull requests
  - [x] Add tests for the new feature.
  - [ ] Add documentation for the new feature.
  - [ ] Add a `CHANGELOG.md` entry for the new feature.


