### PR TITLE
Change config option 'default_suffix' to 'extension' to match other renderers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,15 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Changed
 
-- Nothing.
+- [#67](https://github.com/zendframework/zend-expressive-zendviewrenderer/pull/67)
+  changes configuration option for default template suffix used by NamespacedPathStackResolver
+  to `$config['templates']['extension']` to match other template renderers provided
+  by framework. Default value is `phtml`
 
 ### Deprecated
 
-- Nothing.
+- [#67](https://github.com/zendframework/zend-expressive-zendviewrenderer/pull/67)
+  deprecates configuration option `$config['templates']['default_suffix']`
 
 ### Removed
 

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-zendviewrenderer for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
+ * @copyright Copyright (c) 2017-2019 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-zendviewrenderer/blob/master/LICENSE.md New BSD License
  */
 
@@ -38,7 +38,7 @@ class ConfigProvider
     public function getTemplates() : array
     {
         return [
-            'default_suffix' => 'phtml',
+            'extension' => 'phtml',
             'layout' => 'layout::default',
             'paths' => [],
         ];

--- a/src/ZendViewRendererFactory.php
+++ b/src/ZendViewRendererFactory.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-zendviewrenderer for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
+ * @copyright Copyright (c) 2015-2019 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-zendviewrenderer/blob/master/LICENSE.md New BSD License
  */
 
@@ -60,6 +60,7 @@ class ZendViewRendererFactory
         $config   = $container->has('config') ? $container->get('config') : [];
         $config   = $config['templates'] ?? [];
 
+
         // Configuration
         $resolver = new Resolver\AggregateResolver();
         $resolver->attach(
@@ -76,8 +77,9 @@ class ZendViewRendererFactory
         // Inject helpers
         $this->injectHelpers($renderer, $container);
 
+        $defaultSuffix = $config['extension'] ?? $config['default_suffix'] ?? null;
         // Inject renderer
-        $view = new ZendViewRenderer($renderer, $config['layout'] ?? null, $config['default_suffix'] ?? null);
+        $view = new ZendViewRenderer($renderer, $config['layout'] ?? null, $defaultSuffix);
 
         // Add template paths
         $allPaths = isset($config['paths']) && is_array($config['paths']) ? $config['paths'] : [];

--- a/test/ZendViewRendererFactoryTest.php
+++ b/test/ZendViewRendererFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-zendviewrenderer for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
+ * @copyright Copyright (c) 2015-2019 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-zendviewrenderer/blob/master/LICENSE.md New BSD License
  */
 
@@ -253,6 +253,34 @@ class ZendViewRendererFactoryTest extends TestCase
     }
 
     public function testConfiguresCustomDefaultSuffix()
+    {
+        $config = [
+            'templates' => [
+                'extension' => 'php',
+            ],
+        ];
+
+        $this->container->has('config')->willReturn(true);
+        $this->container->get('config')->willReturn($config);
+        $this->container->has(HelperPluginManager::class)->willReturn(false);
+        $this->container->has(PhpRenderer::class)->willReturn(false);
+
+        $factory = new ZendViewRendererFactory();
+        $view = $factory($this->container->reveal());
+
+        $r = new ReflectionProperty($view, 'resolver');
+        $r->setAccessible(true);
+        $resolver  = $r->getValue($view);
+
+        $this->assertInstanceOf(
+            NamespacedPathStackResolver::class,
+            $resolver,
+            'Expected NamespacedPathStackResolver not found!'
+        );
+        $this->assertEquals('php', $resolver->getDefaultSuffix());
+    }
+
+    public function testConfiguresDeprecatedDefaultSuffix()
     {
         $config = [
             'templates' => [


### PR DESCRIPTION
Provide a narrative description of what you are trying to accomplish:

This PR changes config option for resolver default suffix from `default_suffix` to `extension` to match plates and twig template renderers.
Related: #64 

- [x] Are you creating a new feature?
  - [x] Why is the new feature needed? What purpose does it serve?
    #64  introduced a way to configure default suffix using configuration option `$config['templates']['default_suffix']` however two other template renderers provided by framework use key `extension`
    This PR fixes inconsistency inadvertently introduced by #64 by making use of `extension` key.
  - [x] How will users use the new feature?
    By providing alternative suffix in config:
    ```php
    [
        'templates' => [
            'extension' => 'php',
        ],
    ]
    ```
  - [x] Base your feature on the `develop` branch, and submit against that branch.
  - [x] Add only one feature per pull request; split multiple features over multiple pull requests
  - [x] Add tests for the new feature.
  - [ ] Add documentation for the new feature.
    Documentation needs to be added in another repository
  - [x] Add a `CHANGELOG.md` entry for the new feature.
